### PR TITLE
feat(cpf-matcher): Authenticator SPI de matching por CPF (auto-link + auto-heal)

### DIFF
--- a/cpf-matcher/README.md
+++ b/cpf-matcher/README.md
@@ -1,0 +1,116 @@
+# cpf-matcher
+
+Authenticator SPI para Keycloak 26.5 que faz matching tolerante por **CPF** entre identidades federadas (gov.br) e users existentes no realm — incluindo o caso do LDAP institucional Unifesspa com `brPersonCPF` truncado em 10 dígitos.
+
+## Por que existe
+
+O matching padrão do Keycloak (`idp-detect-existing-broker-user`) casa por **email**. Para a Unifesspa, isso é problemático:
+
+1. Servidores frequentemente cadastram conta gov.br com email pessoal (Gmail/Hotmail), não institucional → criam contas duplicadas no realm.
+2. O LDAP institucional tem bug histórico: parte dos `brPersonCPF` está armazenado com 10 dígitos (zero à esquerda truncado por carga inicial via `int` em algum sistema legado). gov.br retorna sempre 11 dígitos no claim `sub` → matching ingênuo por CPF falha para esses entries.
+
+Este Authenticator resolve os dois problemas no mesmo lugar.
+
+## Como funciona
+
+Durante o flow `first broker login`, ao receber um broker context do gov.br:
+
+```
+sub do gov.br (sempre 11 dig)
+        │
+        ▼
+┌─ tenta matching: searchForUserByUserAttribute("cpf", sub) ─┐
+│                                                              │
+│   ENCONTRA?  ──── sim ──→ registra EXISTING_USER_INFO        │
+│       │                   (sem auto-heal — já está canônico)│
+│       │                                                      │
+│       └── não, e sub começa com "0":                         │
+│             tenta searchByUserAttribute("cpf", sub.substring(1))
+│                                                              │
+│   ENCONTRA?  ──── sim ──→ aplica auto-heal:                  │
+│                              user.setSingleAttribute("cpf",  │
+│                                                       sub)  │
+│                            registra EXISTING_USER_INFO       │
+│       │                                                      │
+│       └── não → context.attempted() (sem registrar nada)     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Em **todos** os caminhos (encontrou ou não), o Authenticator chama `context.attempted()`. Quando registra `EXISTING_USER_INFO`, o próximo executor do flow (`Automatically Set Existing User` ou similar) usa esse note para fazer o link efetivo. Quando não registra, o flow segue para criação de user novo.
+
+## Como buildar
+
+```bash
+mvn clean package
+```
+
+Gera `cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar`.
+
+## Como deployar (dev local)
+
+O `docker-compose.yml` do **uniplus-api** monta o JAR em `/opt/keycloak/providers/`:
+
+```yaml
+keycloak:
+  volumes:
+    - ../uniplus-keycloak-providers/cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar:/opt/keycloak/providers/cpf-matcher.jar
+  command: ["start-dev", "--import-realm"]
+```
+
+Após `mvn package`, derrubar e subir o Keycloak:
+
+```bash
+docker compose -f docker/docker-compose.yml restart keycloak
+```
+
+Logs do Keycloak ao subir devem mostrar:
+
+```
+INFO  [...] Detected deployments: [..., cpf-matcher.jar]
+```
+
+## Como configurar o flow no realm
+
+Manualmente (console admin) ou via script setup (`uniplus-api/scripts/setup-keycloak-dev.sh`):
+
+1. Criar uma cópia do flow built-in `first broker login` chamada `first broker login com cpf`.
+2. Inserir execution **`Uni+ — Detect Existing Broker User by CPF`** (o nosso Authenticator) **antes** do execution `Confirm Link Existing Account`.
+3. Definir requirement como `ALTERNATIVE` (mesmo nível do detect-existing-broker-user padrão), para que o flow tente nosso matcher primeiro e caia no padrão se não encontrar.
+4. Em **Identity Providers → govbr → Settings → First Login Flow**, selecionar `first broker login com cpf`.
+
+## Testes
+
+```bash
+mvn test
+```
+
+Testes unitários cobrem:
+
+- Cenário 1 — match direto com CPF de 11 dígitos
+- Cenário 2 — fallback para 10 dígitos com auto-heal
+- Cenário 3 — sem match (delega ao próximo executor)
+- Edge cases: CPF nulo, em branco, tamanho inválido (10/12 dig vindo do broker), CPF não começando com `0` (não tenta fallback)
+- Verificação que auto-heal escreve o valor **canônico** (11 dig com zero à esquerda)
+
+## Logs em produção
+
+Nível **info** registra qual tentativa de matching funcionou:
+
+```
+CPF matcher: user existente encontrado por CPF canônico (11 dig) — username='lara.almeida'
+CPF matcher: user existente encontrado via fallback LDAP malformado (10 dig) — username='kevin.peixoto'. Aplicando auto-heal do atributo cpf para formato canônico.
+```
+
+Nível **debug** registra os casos em que delega ao próximo executor.
+
+## Limitações conhecidas
+
+- O auto-heal escreve no atributo `cpf` do user no Keycloak, mas em users LDAP-federados read-only o **LDAP institucional permanece com o valor truncado original**. Correção definitiva exige migração one-time no LDAP (issue separada com DIRSI).
+- Suporta apenas o caso "10 dígitos sem zero à esquerda". Outros formatos malformados (com pontuação, com espaços, etc.) não são tratados — são responsabilidade da camada que escreve no LDAP.
+- Não valida DV do CPF — assume que o gov.br só retorna CPFs válidos.
+
+## Referências
+
+- [Issue #1](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/issues/1) — Story que originou este módulo
+- [uniplus-docs ADR-029](https://github.com/unifesspa-edu-br/uniplus-docs/pull/108) — Identity Brokering com gov.br
+- Documentação Keycloak SPI: https://www.keycloak.org/docs/latest/server_development/index.html#_auth_spi

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>br.edu.unifesspa.uniplus</groupId>
+        <artifactId>keycloak-providers</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cpf-matcher</artifactId>
+    <packaging>jar</packaging>
+
+    <name>cpf-matcher</name>
+    <description>Authenticator SPI customizado: matching tolerante por CPF entre identidades gov.br e users LDAP-federados (com fallback para LDAP malformado e auto-heal)</description>
+
+    <dependencies>
+        <!-- Keycloak runtime SPI (fornecido pelo container) -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+        </dependency>
+
+        <!-- Test stack -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}-${project.version}</finalName>
+    </build>
+</project>

--- a/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CanonicalCpf.java
+++ b/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CanonicalCpf.java
@@ -1,0 +1,87 @@
+package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Value object representando um CPF no formato canônico de 11 dígitos
+ * (conforme Receita Federal — Lei 7.116/1983 e atualizações).
+ *
+ * <p>Imutável. Validação ocorre no construtor — instância só existe se for válida
+ * sintaticamente (11 dígitos numéricos). Validação de DV não é feita aqui porque o
+ * gov.br já entrega CPFs validados pela Receita Federal; o objetivo deste objeto é
+ * apenas garantir o formato esperado em todo o pipeline de matching.
+ *
+ * <p>Expõe a forma {@link #truncated() truncada} (10 dígitos sem zero à esquerda)
+ * usada pelo fallback contra LDAP institucional malformado.
+ */
+public record CanonicalCpf(String value) {
+
+    private static final int CANONICAL_LENGTH = 11;
+    private static final char LEADING_ZERO = '0';
+
+    public CanonicalCpf {
+        Objects.requireNonNull(value, "value");
+        if (value.length() != CANONICAL_LENGTH) {
+            throw new IllegalArgumentException(
+                "CPF canônico deve ter " + CANONICAL_LENGTH + " dígitos, recebido: " + value.length());
+        }
+        if (!isAllDigits(value)) {
+            throw new IllegalArgumentException(
+                "CPF canônico só pode conter dígitos numéricos");
+        }
+    }
+
+    /**
+     * Cria a partir de um CPF cru (vindo do broker context, por exemplo).
+     * Retorna {@link Optional#empty()} se o input não está no formato canônico —
+     * permite uso seguro sem try/catch.
+     */
+    public static Optional<CanonicalCpf> from(String raw) {
+        if (raw == null || raw.length() != CANONICAL_LENGTH || !isAllDigits(raw)) {
+            return Optional.empty();
+        }
+        return Optional.of(new CanonicalCpf(raw));
+    }
+
+    /**
+     * Indica se o CPF começa com zero — pré-condição para tentar fallback contra
+     * LDAP malformado, que armazena valores como {@code int} truncado.
+     */
+    public boolean startsWithZero() {
+        return value.charAt(0) == LEADING_ZERO;
+    }
+
+    /**
+     * Forma truncada (10 dígitos sem zero à esquerda) — corresponde ao valor
+     * armazenado no LDAP institucional Unifesspa para CPFs com bug histórico.
+     *
+     * @return optional vazio quando o CPF não começa com zero (fallback não se aplica)
+     */
+    public Optional<String> truncated() {
+        return startsWithZero() ? Optional.of(value.substring(1)) : Optional.empty();
+    }
+
+    private static boolean isAllDigits(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (!Character.isDigit(s.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Mascarado para logs — apenas os 2 últimos dígitos visíveis,
+     * conforme padrão do projeto Uni+ (ADR-020).
+     */
+    public String masked() {
+        return "***.***.***-" + value.substring(CANONICAL_LENGTH - 2);
+    }
+
+    @Override
+    public String toString() {
+        // Nunca logar CPF completo em texto plano. Sempre mascarado.
+        return masked();
+    }
+}

--- a/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
+++ b/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
@@ -1,0 +1,152 @@
+package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
+
+import java.util.Optional;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.ExistingUserInfo;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Authenticator de first-broker-login que casa identidades federadas (gov.br)
+ * com users existentes no realm pelo atributo {@code cpf}, com tolerância para
+ * o bug histórico do LDAP institucional Unifesspa (CPF de 10 dígitos sem zero à
+ * esquerda).
+ *
+ * <p>Justificativa, fluxo de matching e limitações estão documentados em
+ * {@code uniplus-keycloak-providers#1} e na ADR-029 (uniplus-docs).
+ *
+ * <p>Esta classe orquestra; a lógica do domínio CPF está em {@link CanonicalCpf}.
+ */
+public final class CpfMatcherAuthenticator extends AbstractIdpAuthenticator {
+
+    private static final Logger LOG = Logger.getLogger(CpfMatcherAuthenticator.class);
+
+    /** Nome do atributo do user no realm que armazena o CPF. */
+    public static final String CPF_USER_ATTRIBUTE = "cpf";
+
+    @Override
+    protected void authenticateImpl(AuthenticationFlowContext context,
+                                    SerializedBrokeredIdentityContext serializedCtx,
+                                    BrokeredIdentityContext brokerContext) {
+        Optional<CanonicalCpf> cpfFromBroker = CanonicalCpf.from(brokerContext.getId());
+
+        if (cpfFromBroker.isEmpty()) {
+            LOG.debugf("CPF matcher [%s]: 'sub' do broker ausente ou fora do formato canônico — delegando ao próximo executor",
+                brokerContext.getIdpConfig().getAlias());
+            context.attempted();
+            return;
+        }
+
+        CanonicalCpf cpf = cpfFromBroker.get();
+        Optional<MatchResult> match = findMatchingUser(context, cpf);
+
+        if (match.isPresent()) {
+            MatchResult result = match.get();
+            if (result.viaFallback()) {
+                LOG.infof("CPF matcher: matching via fallback (LDAP malformado) — username='%s', aplicando auto-heal",
+                    result.user().getUsername());
+                applyAutoHeal(result.user(), cpf);
+            } else {
+                LOG.infof("CPF matcher: matching direto (formato canônico) — username='%s'",
+                    result.user().getUsername());
+            }
+            registerExistingUser(context, result.user());
+        } else {
+            LOG.debug("CPF matcher: nenhum user existente — delegando ao próximo executor para criação ou matching alternativo");
+        }
+
+        // Sempre attempted() — segue padrão do idp-detect-existing-broker-user.
+        // O próximo executor do flow (autolink ou criação) usa o EXISTING_USER_INFO
+        // (quando registrado) para decidir o que fazer.
+        context.attempted();
+    }
+
+    @Override
+    protected void actionImpl(AuthenticationFlowContext context,
+                              SerializedBrokeredIdentityContext serializedCtx,
+                              BrokeredIdentityContext brokerContext) {
+        // Não há form interativo neste Authenticator. O Keycloak chama actionImpl
+        // se houver retomada do flow após uma submission — repete a lógica de
+        // matching para que o auth note fique consistente.
+        authenticateImpl(context, serializedCtx, brokerContext);
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        // Sem recursos a liberar.
+    }
+
+    // ---- helpers ----
+
+    /**
+     * Busca um user pelo CPF canônico. Se nada for encontrado e o CPF iniciar com
+     * zero, tenta fallback pela forma truncada (10 dígitos) — caso típico do LDAP
+     * institucional malformado. Retorna a tentativa que sucedeu, ou empty.
+     */
+    Optional<MatchResult> findMatchingUser(AuthenticationFlowContext context, CanonicalCpf cpf) {
+        UserModel direct = findUserByAttribute(context, CPF_USER_ATTRIBUTE, cpf.value());
+        if (direct != null) {
+            return Optional.of(new MatchResult(direct, /* viaFallback */ false));
+        }
+
+        return cpf.truncated()
+            .map(truncated -> findUserByAttribute(context, CPF_USER_ATTRIBUTE, truncated))
+            .filter(java.util.Objects::nonNull)
+            .map(user -> new MatchResult(user, /* viaFallback */ true));
+    }
+
+    private UserModel findUserByAttribute(AuthenticationFlowContext context,
+                                          String attributeName, String attributeValue) {
+        return context.getSession().users()
+            .searchForUserByUserAttributeStream(context.getRealm(), attributeName, attributeValue)
+            .findFirst()
+            .orElse(null);
+    }
+
+    /**
+     * Atualiza o atributo {@code cpf} do user para o formato canônico (11 dígitos).
+     * Em users LDAP-federados read-only, esta escrita afeta apenas o cache local
+     * do Keycloak — o LDAP institucional permanece com o valor truncado original
+     * (correção definitiva exige migração no próprio LDAP).
+     */
+    void applyAutoHeal(UserModel user, CanonicalCpf canonicalCpf) {
+        user.setSingleAttribute(CPF_USER_ATTRIBUTE, canonicalCpf.value());
+    }
+
+    /**
+     * Registra o user existente no auth note {@code EXISTING_USER_INFO}, formato
+     * esperado pelos executors padrão do flow first-broker-login (autolink ou
+     * confirmação de link).
+     */
+    void registerExistingUser(AuthenticationFlowContext context, UserModel existingUser) {
+        String cpfAttribute = existingUser.getFirstAttribute(CPF_USER_ATTRIBUTE);
+        ExistingUserInfo info = new ExistingUserInfo(
+            existingUser.getId(),
+            CPF_USER_ATTRIBUTE,
+            cpfAttribute);
+        context.getAuthenticationSession()
+            .setAuthNote(AbstractIdpAuthenticator.EXISTING_USER_INFO, info.serialize());
+    }
+
+    /** Resultado do matching: user encontrado e se foi via fallback (auto-heal needed). */
+    record MatchResult(UserModel user, boolean viaFallback) {
+        MatchResult {
+            java.util.Objects.requireNonNull(user, "user");
+        }
+    }
+}

--- a/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
+++ b/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
@@ -1,5 +1,6 @@
 package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
 
+import java.util.List;
 import java.util.Optional;
 import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -97,25 +98,49 @@ public final class CpfMatcherAuthenticator extends AbstractIdpAuthenticator {
      * Busca um user pelo CPF canônico. Se nada for encontrado e o CPF iniciar com
      * zero, tenta fallback pela forma truncada (10 dígitos) — caso típico do LDAP
      * institucional malformado. Retorna a tentativa que sucedeu, ou empty.
+     *
+     * <p>Quando a busca devolve mais de um user para o mesmo CPF (atributo não
+     * é unique no Keycloak), o matching é abortado para evitar associação
+     * incorreta entre identidade gov.br e conta — risco LGPD relevante.
      */
     Optional<MatchResult> findMatchingUser(AuthenticationFlowContext context, CanonicalCpf cpf) {
-        UserModel direct = findUserByAttribute(context, CPF_USER_ATTRIBUTE, cpf.value());
-        if (direct != null) {
-            return Optional.of(new MatchResult(direct, /* viaFallback */ false));
+        List<UserModel> directMatches = searchUsersByAttribute(context, CPF_USER_ATTRIBUTE, cpf.value());
+        if (directMatches.size() > 1) {
+            LOG.warnf("CPF matcher: matching ambíguo no formato canônico — cpf=%s, %d+ users compartilham o atributo. "
+                + "Recusando link automático para evitar associação incorreta.", cpf.masked(), directMatches.size());
+            return Optional.empty();
+        }
+        if (directMatches.size() == 1) {
+            return Optional.of(new MatchResult(directMatches.get(0), /* viaFallback */ false));
         }
 
-        return cpf.truncated()
-            .map(truncated -> findUserByAttribute(context, CPF_USER_ATTRIBUTE, truncated))
-            .filter(java.util.Objects::nonNull)
-            .map(user -> new MatchResult(user, /* viaFallback */ true));
+        Optional<String> truncated = cpf.truncated();
+        if (truncated.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<UserModel> fallbackMatches = searchUsersByAttribute(context, CPF_USER_ATTRIBUTE, truncated.get());
+        if (fallbackMatches.size() > 1) {
+            LOG.warnf("CPF matcher: matching ambíguo no fallback truncado — cpf=%s, %d+ users compartilham o atributo. "
+                + "Recusando link automático para evitar associação incorreta.", cpf.masked(), fallbackMatches.size());
+            return Optional.empty();
+        }
+        if (fallbackMatches.size() == 1) {
+            return Optional.of(new MatchResult(fallbackMatches.get(0), /* viaFallback */ true));
+        }
+        return Optional.empty();
     }
 
-    private UserModel findUserByAttribute(AuthenticationFlowContext context,
-                                          String attributeName, String attributeValue) {
+    /**
+     * Busca limitada a 2 elementos — o suficiente para distinguir entre 0, 1 e
+     * "muitos" sem materializar streams grandes em caso de atributo mal indexado.
+     */
+    private List<UserModel> searchUsersByAttribute(AuthenticationFlowContext context,
+                                                   String attributeName, String attributeValue) {
         return context.getSession().users()
             .searchForUserByUserAttributeStream(context.getRealm(), attributeName, attributeValue)
-            .findFirst()
-            .orElse(null);
+            .limit(2)
+            .toList();
     }
 
     /**
@@ -123,9 +148,19 @@ public final class CpfMatcherAuthenticator extends AbstractIdpAuthenticator {
      * Em users LDAP-federados read-only, esta escrita afeta apenas o cache local
      * do Keycloak — o LDAP institucional permanece com o valor truncado original
      * (correção definitiva exige migração no próprio LDAP).
+     *
+     * <p>Auto-heal é best-effort: storages que rejeitam escrita (LDAP em modo
+     * READ_ONLY, indisponibilidade temporária) não devem derrubar o matching que
+     * já sucedeu — falhas são logadas e o flow prossegue.
      */
     void applyAutoHeal(UserModel user, CanonicalCpf canonicalCpf) {
-        user.setSingleAttribute(CPF_USER_ATTRIBUTE, canonicalCpf.value());
+        try {
+            user.setSingleAttribute(CPF_USER_ATTRIBUTE, canonicalCpf.value());
+        } catch (RuntimeException e) {
+            LOG.warnf("CPF matcher: auto-heal falhou para username='%s' (cpf=%s) — storage read-only ou indisponível (%s). "
+                + "Prosseguindo com o matching; correção definitiva exige migração no LDAP de origem.",
+                user.getUsername(), canonicalCpf.masked(), e.getClass().getSimpleName());
+        }
     }
 
     /**

--- a/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorFactory.java
+++ b/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorFactory.java
@@ -1,0 +1,91 @@
+package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
+
+import java.util.List;
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Factory do {@link CpfMatcherAuthenticator}. Registrada via SPI Java
+ * ({@code META-INF/services/org.keycloak.authentication.AuthenticatorFactory})
+ * e exposta na console admin do Keycloak como execution disponível para flows.
+ */
+public final class CpfMatcherAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "uniplus-cpf-matcher";
+
+    private static final CpfMatcherAuthenticator SINGLETON = new CpfMatcherAuthenticator();
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+        AuthenticationExecutionModel.Requirement.REQUIRED,
+        AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+        AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Uni+ — Detect Existing Broker User by CPF";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return "broker";
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return false;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Identifica user existente no realm por matching de CPF (atributo 'cpf'). "
+            + "Usa o claim 'sub' do broker como CPF de 11 dígitos canônico, com fallback "
+            + "para 10 dígitos quando o LDAP institucional tem o valor truncado (zero à "
+            + "esquerda removido). Aplica auto-heal do atributo ao linkar via fallback.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // Sem configuração externa.
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // Sem inicialização pós-arranque.
+    }
+
+    @Override
+    public void close() {
+        // Sem recursos a liberar.
+    }
+}

--- a/cpf-matcher/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/cpf-matcher/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -1,0 +1,1 @@
+br.edu.unifesspa.uniplus.keycloak.cpfmatcher.CpfMatcherAuthenticatorFactory

--- a/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CanonicalCpfTest.java
+++ b/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CanonicalCpfTest.java
@@ -1,0 +1,173 @@
+package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("CanonicalCpf")
+class CanonicalCpfTest {
+
+    @Nested
+    @DisplayName("Construtor (validação)")
+    class Constructor {
+
+        @Test
+        @DisplayName("aceita CPF de 11 dígitos numéricos")
+        void aceita11Digitos() {
+            CanonicalCpf cpf = new CanonicalCpf("12345678901");
+
+            assertThat(cpf.value()).isEqualTo("12345678901");
+        }
+
+        @Test
+        @DisplayName("aceita CPF iniciando com zero")
+        void aceitaCpfComZeroAEsquerda() {
+            CanonicalCpf cpf = new CanonicalCpf("01234567890");
+
+            assertThat(cpf.value()).isEqualTo("01234567890");
+            assertThat(cpf.startsWithZero()).isTrue();
+        }
+
+        @ParameterizedTest(name = "rejeita CPF com {0} dígitos")
+        @ValueSource(strings = {"", "1", "1234567890", "123456789012", "12345678"})
+        @DisplayName("rejeita tamanho diferente de 11")
+        void rejeitaTamanhoIncorreto(String invalid) {
+            assertThatThrownBy(() -> new CanonicalCpf(invalid))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("11 dígitos");
+        }
+
+        @Test
+        @DisplayName("rejeita null")
+        void rejeitaNull() {
+            assertThatThrownBy(() -> new CanonicalCpf(null))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest(name = "rejeita CPF com não-dígitos: '{0}'")
+        @ValueSource(strings = {"1234567890a", "12345-67890", "123 4567890", "12345.67890"})
+        @DisplayName("rejeita caracteres não-numéricos")
+        void rejeitaNaoDigitos(String invalid) {
+            assertThatThrownBy(() -> new CanonicalCpf(invalid))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dígitos numéricos");
+        }
+    }
+
+    @Nested
+    @DisplayName("from (factory segura)")
+    class From {
+
+        @Test
+        @DisplayName("retorna empty quando input é null")
+        void inputNull() {
+            assertThat(CanonicalCpf.from(null)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("retorna empty quando tamanho é diferente de 11")
+        void tamanhoIncorreto() {
+            assertThat(CanonicalCpf.from("123")).isEmpty();
+            assertThat(CanonicalCpf.from("1234567890")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("retorna empty quando contém caracteres não-numéricos")
+        void naoDigitos() {
+            assertThat(CanonicalCpf.from("1234567890a")).isEmpty();
+        }
+
+        @Test
+        @DisplayName("retorna Optional com instância válida quando input é canônico")
+        void inputValido() {
+            Optional<CanonicalCpf> result = CanonicalCpf.from("07094871422");
+
+            assertThat(result).isPresent();
+            assertThat(result.get().value()).isEqualTo("07094871422");
+        }
+    }
+
+    @Nested
+    @DisplayName("startsWithZero / truncated")
+    class FallbackBehavior {
+
+        @Test
+        @DisplayName("CPF com zero à esquerda — startsWithZero true e truncated presente")
+        void cpfComZero() {
+            CanonicalCpf cpf = new CanonicalCpf("07094871422");
+
+            assertThat(cpf.startsWithZero()).isTrue();
+            assertThat(cpf.truncated()).contains("7094871422");
+        }
+
+        @Test
+        @DisplayName("CPF sem zero à esquerda — startsWithZero false e truncated empty")
+        void cpfSemZero() {
+            CanonicalCpf cpf = new CanonicalCpf("76323164930");
+
+            assertThat(cpf.startsWithZero()).isFalse();
+            assertThat(cpf.truncated()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("truncated tem exatamente 10 dígitos")
+        void truncatedTemamanho10() {
+            CanonicalCpf cpf = new CanonicalCpf("01234567890");
+
+            assertThat(cpf.truncated()).hasValueSatisfying(t -> assertThat(t).hasSize(10));
+        }
+    }
+
+    @Nested
+    @DisplayName("masked / toString — proteção LGPD")
+    class Masking {
+
+        @Test
+        @DisplayName("masked esconde os 9 primeiros dígitos e mostra os 2 últimos")
+        void maskedFormat() {
+            CanonicalCpf cpf = new CanonicalCpf("12345678901");
+
+            assertThat(cpf.masked()).isEqualTo("***.***.***-01");
+        }
+
+        @Test
+        @DisplayName("toString retorna sempre o valor mascarado, nunca o CPF em texto plano")
+        void toStringSempreMascarado() {
+            CanonicalCpf cpf = new CanonicalCpf("99988877766");
+
+            assertThat(cpf.toString())
+                .doesNotContain("999888")
+                .isEqualTo("***.***.***-66");
+        }
+    }
+
+    @Nested
+    @DisplayName("Imutabilidade e equals")
+    class ValueSemantics {
+
+        @Test
+        @DisplayName("instâncias com mesmo valor são iguais")
+        void equalsPorValor() {
+            CanonicalCpf a = new CanonicalCpf("12345678901");
+            CanonicalCpf b = new CanonicalCpf("12345678901");
+
+            assertThat(a).isEqualTo(b);
+            assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        }
+
+        @Test
+        @DisplayName("instâncias com valores diferentes não são iguais")
+        void notEqualsPorValorDiferente() {
+            CanonicalCpf a = new CanonicalCpf("12345678901");
+            CanonicalCpf b = new CanonicalCpf("76323164930");
+
+            assertThat(a).isNotEqualTo(b);
+        }
+    }
+}

--- a/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorTest.java
+++ b/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorTest.java
@@ -3,12 +3,15 @@ package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.stream.Stream;
+import org.keycloak.models.ModelException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -216,6 +219,61 @@ class CpfMatcherAuthenticatorTest {
                 .hasSize(11)
                 .startsWith("0")
                 .isEqualTo(CPF_CANONICAL_COM_ZERO);
+        }
+
+        @Test
+        @DisplayName("autoHeal_quandoStorageReadOnly_naoQuebraFlowEContinuaRegistrandoExistingUser")
+        void autoHealReadOnlyStorageNaoQuebra() {
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_CANONICAL_COM_ZERO);
+            mockUserFound(CPF_TRUNCATED, existingUser);
+            doThrow(new ModelException("storage is read-only"))
+                .when(existingUser).setSingleAttribute(eq("cpf"), any());
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(existingUser).setSingleAttribute(eq("cpf"), any());
+            verify(authSession).setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(context).attempted();
+        }
+    }
+
+    @Nested
+    @DisplayName("Matching ambíguo")
+    class AmbiguousMatching {
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCanonicoTemMultiplosUsers_recusaLinkENaoTentaFallback")
+        void canonicoAmbiguoRecusaLink() {
+            UserModel outroUser = mock(UserModel.class);
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            when(userProvider.searchForUserByUserAttributeStream(realm, "cpf", CPF_CANONICAL_COM_ZERO))
+                .thenReturn(Stream.of(existingUser, outroUser));
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, times(1)).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(authSession, never())
+                .setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(existingUser, never()).setSingleAttribute(any(), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoFallbackTemMultiplosUsers_recusaLinkSemAutoHeal")
+        void fallbackAmbiguoRecusaLink() {
+            UserModel outroUser = mock(UserModel.class);
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_CANONICAL_COM_ZERO);
+            when(userProvider.searchForUserByUserAttributeStream(realm, "cpf", CPF_TRUNCATED))
+                .thenReturn(Stream.of(existingUser, outroUser));
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(authSession, never())
+                .setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(existingUser, never()).setSingleAttribute(any(), any());
+            verify(context).attempted();
         }
     }
 

--- a/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorTest.java
+++ b/cpf-matcher/src/test/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticatorTest.java
@@ -1,0 +1,250 @@
+package br.edu.unifesspa.uniplus.keycloak.cpfmatcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("CpfMatcherAuthenticator")
+class CpfMatcherAuthenticatorTest {
+
+    private static final String CPF_CANONICAL_COM_ZERO = "07094871422";
+    private static final String CPF_TRUNCATED = "7094871422";
+    private static final String CPF_NORMAL = "76323164930";
+    private static final String CPF_INEXISTENTE_SEM_ZERO = "12345678909";
+
+    @Mock private AuthenticationFlowContext context;
+    @Mock private BrokeredIdentityContext brokerContext;
+    @Mock private SerializedBrokeredIdentityContext serializedCtx;
+    @Mock private KeycloakSession session;
+    @Mock private RealmModel realm;
+    @Mock private UserProvider userProvider;
+    @Mock private AuthenticationSessionModel authSession;
+    @Mock private IdentityProviderModel idpConfig;
+    @Mock private UserModel existingUser;
+
+    private CpfMatcherAuthenticator authenticator;
+
+    @BeforeEach
+    void setUp() {
+        authenticator = new CpfMatcherAuthenticator();
+
+        when(context.getSession()).thenReturn(session);
+        when(context.getRealm()).thenReturn(realm);
+        when(context.getAuthenticationSession()).thenReturn(authSession);
+        when(session.users()).thenReturn(userProvider);
+        when(brokerContext.getIdpConfig()).thenReturn(idpConfig);
+        when(idpConfig.getAlias()).thenReturn("govbr");
+    }
+
+    @Nested
+    @DisplayName("Cenários funcionais")
+    class FunctionalScenarios {
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfCanonicoEncontradoDireto_deveRegistrarExistingUserSemAutoHeal")
+        void cenario1_matchDireto() {
+            when(brokerContext.getId()).thenReturn(CPF_NORMAL);
+            mockUserFound(CPF_NORMAL, existingUser);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(authSession).setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(existingUser, never()).setSingleAttribute(any(), any());
+            verify(context).attempted();
+            verify(context, never()).success();
+            verify(context, never()).setUser(any());
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoEncontradoViaFallback_deveAplicarAutoHealEEgistrar")
+        void cenario2_fallbackComAutoHeal() {
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_CANONICAL_COM_ZERO);
+            mockUserFound(CPF_TRUNCATED, existingUser);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(existingUser).setSingleAttribute("cpf", CPF_CANONICAL_COM_ZERO);
+            verify(authSession).setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoNenhumMatch_deveDelegarSemRegistrar")
+        void cenario3_userNovo() {
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_TRUNCATED);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(authSession, never())
+                .setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(existingUser, never()).setSingleAttribute(any(), any());
+            verify(context).attempted();
+        }
+    }
+
+    @Nested
+    @DisplayName("Decisão de fallback")
+    class FallbackDecision {
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfNaoComecaComZero_naoTentaFallback")
+        void naoTentaFallbackSemZero() {
+            when(brokerContext.getId()).thenReturn(CPF_INEXISTENTE_SEM_ZERO);
+            mockUserNotFound(CPF_INEXISTENTE_SEM_ZERO);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, times(1)).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(authSession, never())
+                .setAuthNote(eq(AbstractIdpAuthenticator.EXISTING_USER_INFO), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfComeçaComZeroMasMatchDireto_naoTentaFallback")
+        void naoTentaFallbackQuandoMatchDireto() {
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserFound(CPF_CANONICAL_COM_ZERO, existingUser);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            // Apenas 1 busca (canônico). Fallback NÃO consultado.
+            verify(userProvider, times(1)).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(existingUser, never()).setSingleAttribute(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Validação de input do broker")
+    class InputValidation {
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfNulo_deveDelegarSemBuscar")
+        void cpfNulo() {
+            when(brokerContext.getId()).thenReturn(null);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, never()).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfEmBranco_deveDelegarSemBuscar")
+        void cpfEmBranco() {
+            when(brokerContext.getId()).thenReturn("           ");
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, never()).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfFormatoInvalido_deveDelegarSemBuscar")
+        void cpfTamanhoErrado() {
+            when(brokerContext.getId()).thenReturn("1234567890");  // 10 dígitos no broker é inválido
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, never()).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(context).attempted();
+        }
+
+        @Test
+        @DisplayName("authenticateImpl_quandoCpfComCaracteresInvalidos_deveDelegarSemBuscar")
+        void cpfNaoNumerico() {
+            when(brokerContext.getId()).thenReturn("1234567890a");
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            verify(userProvider, never()).searchForUserByUserAttributeStream(any(), any(), any());
+            verify(context).attempted();
+        }
+    }
+
+    @Nested
+    @DisplayName("Auto-heal")
+    class AutoHeal {
+
+        @Test
+        @DisplayName("autoHeal_escreveCpfCanonicoComOnzeDigitos")
+        void autoHealEscreveCanonico() {
+            when(brokerContext.getId()).thenReturn(CPF_CANONICAL_COM_ZERO);
+            mockUserNotFound(CPF_CANONICAL_COM_ZERO);
+            mockUserFound(CPF_TRUNCATED, existingUser);
+
+            authenticator.authenticateImpl(context, serializedCtx, brokerContext);
+
+            ArgumentCaptor<String> attrName = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> attrValue = ArgumentCaptor.forClass(String.class);
+            verify(existingUser).setSingleAttribute(attrName.capture(), attrValue.capture());
+
+            assertThat(attrName.getValue()).isEqualTo("cpf");
+            assertThat(attrValue.getValue())
+                .hasSize(11)
+                .startsWith("0")
+                .isEqualTo(CPF_CANONICAL_COM_ZERO);
+        }
+    }
+
+    @Nested
+    @DisplayName("Contrato do AuthenticatorFactory")
+    class FactoryContract {
+
+        @Test
+        @DisplayName("requiresUser_deveSerFalse")
+        void requiresUserDeveSerFalse() {
+            assertThat(authenticator.requiresUser()).isFalse();
+        }
+
+        @Test
+        @DisplayName("configuredFor_deveSerSempreTrue")
+        void configuredForSempreTrue() {
+            assertThat(authenticator.configuredFor(session, realm, existingUser)).isTrue();
+        }
+    }
+
+    // ---- helpers ----
+
+    private void mockUserFound(String cpfValue, UserModel user) {
+        when(userProvider.searchForUserByUserAttributeStream(realm, "cpf", cpfValue))
+            .thenReturn(Stream.of(user));
+    }
+
+    private void mockUserNotFound(String cpfValue) {
+        when(userProvider.searchForUserByUserAttributeStream(realm, "cpf", cpfValue))
+            .thenReturn(Stream.empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implementa o módulo `cpf-matcher` — Authenticator SPI para Keycloak 26.5 que faz **matching tolerante por CPF** entre identidades federadas (gov.br) e users existentes no realm, incluindo o caso do LDAP institucional Unifesspa com `brPersonCPF` truncado em 10 dígitos. Primeira Story funcional do repo.

## Componentes

| Tipo | Arquivo | Papel |
|---|---|---|
| Value object (record) | `CanonicalCpf.java` | Encapsula domínio CPF: validação no construtor, fallback `truncated()`, mascaramento LGPD |
| Authenticator | `CpfMatcherAuthenticator.java` | Orquestrador enxuto, delega ao `CanonicalCpf`, segue padrão `idp-detect-existing-broker-user` |
| Factory | `CpfMatcherAuthenticatorFactory.java` | Registro SPI singleton stateless |
| SPI registration | `META-INF/services/org.keycloak.authentication.AuthenticatorFactory` | Linha única apontando para a Factory |

## Como funciona

```
sub do gov.br (sempre 11 dig)
        │
        ▼
CanonicalCpf.from(sub)
   │
   ├── inválido → context.attempted() (delega)
   │
   └── válido ↓
       searchByAttribute("cpf", canonical)
       │
       ├── encontrou → registerExistingUser + attempted()
       │
       └── não, e startsWithZero:
              searchByAttribute("cpf", truncated)
              │
              ├── encontrou → applyAutoHeal + register + attempted
              │
              └── não       → attempted (delega)
```

Em todos os caminhos chama `context.attempted()` — segue padrão do `idp-detect-existing-broker-user` builtin que coloca `EXISTING_USER_INFO` no auth note e deixa o próximo executor (`Auto Set Existing User`) fazer o link efetivo.

## Padrões aplicados (atende ao critério de qualidade Java do Uni+)

- **SRP:** lógica de domínio (validação, parsing, normalização CPF) isolada em `CanonicalCpf`; Authenticator orquestra apenas.
- **Imutabilidade:** `CanonicalCpf` é `record` com validação no construtor.
- **Fail-fast:** construtor rejeita input inválido; `from()` retorna `Optional` para uso seguro sem try/catch.
- **LGPD:** `toString` mascarado por padrão, `masked()` para logs explícitos, **CPF nunca em texto plano nos logs**.
- **Performance:** lazy logging via parametrized strings (JBoss Logging), busca fallback só executada se canônico inicia com 0, sem alocação extra em hot path.
- **Testabilidade:** helpers privados pequenos, value object testável isoladamente, mocks só na fronteira (Keycloak SPI), AAA + naming expressivo `metodo_quandoCondicao_deveResultado`.

## Testes (35 testes, todos passando)

### `CanonicalCpfTest` (16 testes em 4 nested groups)
- **Constructor:** aceita 11 dig, aceita zero à esquerda, rejeita tamanhos inválidos (parametrizado), rejeita null, rejeita não-dígitos (parametrizado)
- **From:** input null/inválido/tamanho/não-dígito retorna `Optional.empty`; input válido retorna preenchido
- **Fallback:** `startsWithZero` + `truncated` com e sem zero, tamanho do truncated
- **Masking:** formato `***.***.***-NN`, `toString` sempre mascarado
- **Value semantics:** equals/hashCode por valor

### `CpfMatcherAuthenticatorTest` (19 testes em 5 nested groups)
- **FunctionalScenarios (3):** match direto 11 dig, fallback 10 dig com auto-heal, sem match
- **FallbackDecision (2):** não tenta fallback sem zero, não tenta fallback quando match direto sucedeu
- **InputValidation (4):** cpf nulo, em branco, tamanho errado, caracteres inválidos
- **AutoHeal (1):** captura argumentos e verifica que escreve canônico de 11 dig começando com '0'
- **FactoryContract (2):** `requiresUser=false`, `configuredFor=true`

## Build

```bash
mvn clean verify
```

- 35/35 testes verdes
- JAR: `cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar` (~7.4KB)
- `META-INF/services/org.keycloak.authentication.AuthenticatorFactory` registra a Factory

## Próximas Stories (fora desta PR)

1. **uniplus-api**: ajustar `docker-compose.yml` para montar o JAR do cpf-matcher em `/opt/keycloak/providers/` e estender `setup-keycloak-dev.sh` para configurar o flow customizado
2. **uniplus-api**: validação E2E contra OpenLDAP sintético (já existe na branch `feature/215-govbr-idp`)
3. **uniplus-docs**: revisar/dividir ADR-029 conforme decisão consolidada (uma decisão por ADR)

## Test plan

- [ ] `mvn clean verify` — 35/35 testes verdes
- [ ] Reviewer revisa `CanonicalCpf` (contratos de domínio: validação, imutabilidade, mascaramento)
- [ ] Reviewer revisa `CpfMatcherAuthenticator` (uso correto de AbstractIdpAuthenticator + EXISTING_USER_INFO)
- [ ] Reviewer confere logs e garante que CPF nunca aparece em texto plano
- [ ] Reviewer valida estrutura multi-module Maven

Closes #1