### PR TITLE
ci: corrige gate de PR para aceitar membership privada da org

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,7 +12,7 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
-      - name: Validate author has write access to the repo
+      - name: Validate author is org member with write access
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -20,19 +20,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Consulta a permissão efetiva do autor no repo. Esse endpoint
-          # considera membership privada da org (diferente de
-          # author_association no payload, que só reflete relações públicas),
-          # então Owners e Members da org com write access aparecem aqui
-          # mesmo quando a membership está oculta no perfil.
+          # 1) Permissão efetiva no repo. Esse endpoint considera membership
+          #    privada da org — Owners e Members aparecem aqui com a permissão
+          #    herdada (admin/write) mesmo quando a relação está oculta no
+          #    perfil, ao contrário de github.event.pull_request.author_association
+          #    que só reflete relações públicas.
           permission=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq .permission)
 
           case "$permission" in
-            admin|maintain|write)
-              echo "PR author $AUTHOR autorizado (permission=$permission)."
-              ;;
+            admin|maintain|write) ;;
             *)
-              echo "::error::PR author $AUTHOR não tem permissão de escrita no repo (permission=$permission)."
+              echo "::error::PR author $AUTHOR não tem permissão de escrita no repo $REPO (permission=$permission). Solicite acesso a um Owner da org unifesspa-edu-br."
               exit 1
               ;;
           esac
+
+          # 2) Rejeita outside collaborators. Quem aparece em ?affiliation=outside
+          #    foi adicionado direto ao repo (Settings > Collaborators) sem
+          #    entrar na org — tem write efetivo, mas o gate promete validar
+          #    membership *na org*. Sem essa cláusula, contractors externos
+          #    com write passariam pela cláusula 1 e desbloqueariam o status
+          #    check obrigatório.
+          is_outside=$(gh api "repos/$REPO/collaborators?affiliation=outside&per_page=100" \
+            --jq "[.[].login] | index(\"$AUTHOR\") != null")
+
+          if [ "$is_outside" = "true" ]; then
+            echo "::error::PR author $AUTHOR é outside collaborator e não é membro da org unifesspa-edu-br. O gate exige membership na org."
+            exit 1
+          fi
+
+          echo "PR author $AUTHOR autorizado (permission=$permission, membro da org)."

--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,17 +12,27 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
-      - name: Validate author association
+      - name: Validate author has write access to the repo
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
-          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          case "$ASSOCIATION" in
-            MEMBER|OWNER)
-              echo "PR author $AUTHOR is associated as $ASSOCIATION."
+          set -euo pipefail
+
+          # Consulta a permissão efetiva do autor no repo. Esse endpoint
+          # considera membership privada da org (diferente de
+          # author_association no payload, que só reflete relações públicas),
+          # então Owners e Members da org com write access aparecem aqui
+          # mesmo quando a membership está oculta no perfil.
+          permission=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq .permission)
+
+          case "$permission" in
+            admin|maintain|write)
+              echo "PR author $AUTHOR autorizado (permission=$permission)."
               ;;
             *)
-              echo "::error::PR author $AUTHOR is not a member of unifesspa-edu-br (author_association=$ASSOCIATION)."
+              echo "::error::PR author $AUTHOR não tem permissão de escrita no repo (permission=$permission)."
               exit 1
               ;;
           esac


### PR DESCRIPTION
## Summary

- O gate `PR author is org member` lê `github.event.pull_request.author_association` do payload, que só reflete relações **públicas** com a org. Owners/Members cuja membership está privada vêm como `CONTRIBUTOR` e o PR é bloqueado indevidamente.
- Caso concreto: [PR #2](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/pull/2) bloqueado mesmo com autor sendo Owner da org (`marmota-alpina`).
- Correção: consultar `repos/{repo}/collaborators/{user}/permission`, que retorna a permissão efetiva considerando inclusive membership privada. Aceita `admin`/`maintain`/`write`.

## Como verifiquei

- `gh api repos/unifesspa-edu-br/uniplus-keycloak-providers/collaborators/marmota-alpina/permission` retorna `{"permission":"admin"}` mesmo com membership privada.
- `permissions.contents: read` no `GITHUB_TOKEN` já basta para chamar esse endpoint — sem necessidade de PAT.

## Observação

Workflows com `pull_request` rodam a versão da branch base, então **este próprio PR ainda dispara o gate antigo** e provavelmente reportará o status como falho. Como `enforce_admins=false` na proteção da `main`, um Owner consegue fazer merge mesmo com o check vermelho.

## Próximos passos

Após o merge aqui, replicar o mesmo ajuste em `uniplus-api`, `uniplus-web`, `uniplus-docs` e `uniplus-infra` (todos com o mesmo blob SHA hoje).

## Test plan

- [ ] Após merge, re-run do workflow no PR #2 deve ficar verde.
- [ ] Abrir PR de teste com qualquer Member da org (membership privada) deve passar.