### PR TITLE
ci(github): valida autor via API de permissões (suporta membership privada)

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,17 +12,41 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
-      - name: Validate author association
+      - name: Validate author is org member with write access
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
-          ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          case "$ASSOCIATION" in
-            MEMBER|OWNER)
-              echo "PR author $AUTHOR is associated as $ASSOCIATION."
-              ;;
+          set -euo pipefail
+
+          # 1) Permissão efetiva no repo. Esse endpoint considera membership
+          #    privada da org — Owners e Members aparecem aqui com a permissão
+          #    herdada (admin/write) mesmo quando a relação está oculta no
+          #    perfil, ao contrário de github.event.pull_request.author_association
+          #    que só reflete relações públicas.
+          permission=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq .permission)
+
+          case "$permission" in
+            admin|maintain|write) ;;
             *)
-              echo "::error::PR author $AUTHOR is not a member of unifesspa-edu-br (author_association=$ASSOCIATION)."
+              echo "::error::PR author $AUTHOR não tem permissão de escrita no repo $REPO (permission=$permission). Solicite acesso a um Owner da org unifesspa-edu-br."
               exit 1
               ;;
           esac
+
+          # 2) Rejeita outside collaborators. Quem aparece em ?affiliation=outside
+          #    foi adicionado direto ao repo (Settings > Collaborators) sem
+          #    entrar na org — tem write efetivo, mas o gate promete validar
+          #    membership *na org*. Sem essa cláusula, contractors externos
+          #    com write passariam pela cláusula 1 e desbloqueariam o status
+          #    check obrigatório.
+          is_outside=$(gh api "repos/$REPO/collaborators?affiliation=outside&per_page=100" \
+            --jq "[.[].login] | index(\"$AUTHOR\") != null")
+
+          if [ "$is_outside" = "true" ]; then
+            echo "::error::PR author $AUTHOR é outside collaborator e não é membro da org unifesspa-edu-br. O gate exige membership na org."
+            exit 1
+          fi
+
+          echo "PR author $AUTHOR autorizado (permission=$permission, membro da org)."


### PR DESCRIPTION
## Resumo

Substitui a checagem do workflow `pr-author-org-member` por consulta direta ao endpoint `repos/{repo}/collaborators/{user}/permission`, alinhando este repo ao padrão já em uso em `uniplus-docs` (e api/web).

## Problema

A versão atual em main (commit `876eed0`) lê `github.event.pull_request.author_association` para validar o autor. Esse campo do payload do GitHub **só reflete memberships públicas** da org — qualquer member com perfil privado chega como `CONTRIBUTOR`, mesmo sendo admin.

Resultado prático: o PR #2 (`feat(cpf-matcher): Authenticator SPI`) está com o status check vermelho mesmo o autor sendo admin direto da org `unifesspa-edu-br`.

## Solução

Padrão equivalente ao `uniplus-docs/.github/workflows/pr-author-org-member.yml`:

1. Consulta `gh api repos/$REPO/collaborators/$AUTHOR/permission` — esse endpoint enxerga membership privada e retorna a permissão herdada (`admin`/`maintain`/`write`).
2. Rejeita explicitamente outside collaborators via `?affiliation=outside`, para que contractors externos com write direto no repo não desbloqueiem o gate.

Comentários inline no YAML documentam a justificativa de cada cláusula.

## Pós-merge

Rebase do PR #2 em `origin/main` deve fazer o status check passar.

## Test plan

- [ ] Merge desta PR
- [ ] Rebase do PR #2 em `origin/main`
- [ ] Confirmar `PR author is org member` verde no PR #2

Refs: #2