### PR TITLE
fix(cpf-matcher): mascarar username em logs para conformidade LGPD

### DIFF
--- a/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
+++ b/cpf-matcher/src/main/java/br/edu/unifesspa/uniplus/keycloak/cpfmatcher/CpfMatcherAuthenticator.java
@@ -49,12 +49,14 @@ public final class CpfMatcherAuthenticator extends AbstractIdpAuthenticator {
         if (match.isPresent()) {
             MatchResult result = match.get();
             if (result.viaFallback()) {
-                LOG.infof("CPF matcher: matching via fallback (LDAP malformado) — username='%s', aplicando auto-heal",
-                    result.user().getUsername());
+                // userId (UUID interno do Keycloak) em vez de username — username
+                // no LDAP institucional é nome.sobrenome, dado pessoal LGPD.
+                LOG.infof("CPF matcher: matching via fallback (LDAP malformado) — userId='%s', aplicando auto-heal",
+                    result.user().getId());
                 applyAutoHeal(result.user(), cpf);
             } else {
-                LOG.infof("CPF matcher: matching direto (formato canônico) — username='%s'",
-                    result.user().getUsername());
+                LOG.infof("CPF matcher: matching direto (formato canônico) — userId='%s'",
+                    result.user().getId());
             }
             registerExistingUser(context, result.user());
         } else {
@@ -157,9 +159,9 @@ public final class CpfMatcherAuthenticator extends AbstractIdpAuthenticator {
         try {
             user.setSingleAttribute(CPF_USER_ATTRIBUTE, canonicalCpf.value());
         } catch (RuntimeException e) {
-            LOG.warnf("CPF matcher: auto-heal falhou para username='%s' (cpf=%s) — storage read-only ou indisponível (%s). "
+            LOG.warnf("CPF matcher: auto-heal falhou para userId='%s' (cpf=%s) — storage read-only ou indisponível (%s). "
                 + "Prosseguindo com o matching; correção definitiva exige migração no LDAP de origem.",
-                user.getUsername(), canonicalCpf.masked(), e.getClass().getSimpleName());
+                user.getId(), canonicalCpf.masked(), e.getClass().getSimpleName());
         }
     }
 


### PR DESCRIPTION
## Resumo

Substitui `user.getUsername()` por `user.getId()` nos 3 logs INFO/WARN do `CpfMatcherAuthenticator` para evitar vazamento de PII em logs.

No LDAP institucional Unifesspa, `username` segue o padrão `nome.sobrenome` (ex.: `kevin.peixoto`) — identifica a pessoa por dedução direta, configurando dado pessoal pela LGPD (art. 5º, I). UUID interno do Keycloak não é PII e mantém troubleshooting funcional via Admin Console.

CPF já estava mascarado em todos os logs (`***.***.***-XX`) — a auditoria realizada na Story uniplus-api#218 não identificou outros vazamentos.

## Mudanças

- `CpfMatcherAuthenticator.java` linhas 52, 56, 161 — `getUsername()` → `getId()`, placeholder `username='%s'` → `userId='%s'`
- Comentário inline explicando o motivo (referência a LDAP institucional)

## Validação

- Build limpo
- 38 testes unitários existentes continuam passando (testes não assertavam username — mudança transparente)
- Smoke E2E rodado contra Keycloak local (uniplus-api):
  ```
  CPF matcher: matching via fallback (LDAP malformado) — userId='08661069-8e26-44c0-9d6e-4e96ba2d7e09', aplicando auto-heal
  CPF matcher: auto-heal falhou para userId='92577bf3-8e62-4955-b52d-9ddae0cb0d77' (cpf=***.***.***-22) — storage read-only
  ```
- CPF continua mascarado (regression check passou)

## Test plan

- [x] Build Maven do módulo `cpf-matcher` passa
- [x] 38 testes unitários passam
- [x] Smoke E2E (uniplus-api): matcher continua identificando user existente via fallback de 10 dígitos
- [x] Logs do Keycloak mostram `userId='UUID'` em vez de `username='nome.sobrenome'`
- [x] CPF continua mascarado (`***.***.***-XX`)

## Referências

- Issue: #5
- Auditoria: Story uniplus-api#218
- ADR-020 (uniplus-docs) — padrão de PII masking em logs

Closes #5