### PR TITLE
feat(release): publicar JAR e imagem Keycloak v1.0.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+**/target
+**/.mvn
+**/.idea
+**/.vscode
+*.iml
+*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup Java 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build JAR with tests
+        run: mvn clean package
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          minor="${version%.*}"
+          jar="cpf-matcher/target/cpf-matcher-${version}.jar"
+
+          if [ ! -f "$jar" ]; then
+            echo "::error::JAR esperado não encontrado: $jar"
+            exit 1
+          fi
+
+          sha256sum "$jar" > "${jar}.sha256"
+
+          {
+            echo "version=$version"
+            echo "minor=$minor"
+            echo "jar=$jar"
+            echo "checksum=${jar}.sha256"
+            echo "image=ghcr.io/${GITHUB_REPOSITORY_OWNER}/uniplus-keycloak"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "${{ steps.version.outputs.jar }}" \
+            "${{ steps.version.outputs.checksum }}" \
+            --title "Uni+ Keycloak ${GITHUB_REF_NAME}" \
+            --notes "Release ${GITHUB_REF_NAME} dos providers Keycloak Uni+."
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.title=Uni+ Keycloak
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.version }}
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.minor }}
+            ${{ steps.version.outputs.image }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+WORKDIR /workspace
+
+COPY pom.xml ./
+COPY cpf-matcher/pom.xml cpf-matcher/pom.xml
+COPY cpf-matcher/src cpf-matcher/src
+
+RUN mvn clean package -DskipTests
+
+FROM quay.io/keycloak/keycloak:26.5.7 AS runtime
+
+ARG VERSION=1.0.0
+
+LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-keycloak-providers" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="Uni+ Keycloak" \
+      org.opencontainers.image.version="${VERSION}"
+
+COPY --from=builder /workspace/cpf-matcher/target/cpf-matcher-*.jar /opt/keycloak/providers/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Providers customizados em Java SPI para o **Keycloak** institucional da platafor
 
 - **Java:** 21 LTS
 - **Build:** Maven 3.9+
-- **Keycloak alvo:** 26.5.x
+- **Keycloak alvo:** 26.5.7
 
 ## Build
 
@@ -29,6 +29,58 @@ Os JARs são distribuídos como providers do Keycloak — colocados em `/opt/key
 Em ambiente de **dev local** (uniplus-api), o `docker-compose.yml` faz volume mount do JAR compilado.
 
 Em **homologação/produção**, o JAR é incluído na imagem Docker do Keycloak institucional via Helm chart (Story de operação separada, fora do escopo deste repo).
+
+## Como consumir a imagem
+
+A imagem oficial de consumo dos providers Uni+ é publicada no GHCR:
+
+```bash
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+```
+
+Para **DEV**, substitua a imagem base do Keycloak no `docker-compose.yml` do `uniplus-api`:
+
+```yaml
+image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+```
+
+Essa substituição entra no lugar de `quay.io/keycloak/keycloak:26.5`. O caminho legacy de desenvolvimento local continua suportado para quem trabalha no SPI: compilar o JAR com Maven e montar o arquivo gerado em `/opt/keycloak/providers/`.
+
+Para **HML/PRD**, o Helm chart deve apontar para a mesma imagem versionada:
+
+```text
+ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+```
+
+A imagem precisa ficar pública após o primeiro push, porque o repositório é público e DEV/HML/PRD não devem depender de autenticação para pull. No GitHub, confira em **Packages > uniplus-keycloak > Package settings > Danger Zone > Change visibility** e ajuste para **Public** se necessário.
+
+## Como fazer release
+
+1. Ajustar o `pom.xml` para a próxima versão sem `-SNAPSHOT`.
+2. Executar `mvn clean package` e validar os testes.
+3. Fazer commit e push da alteração.
+4. Criar e enviar a tag:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `1.0.0`, `1.0` e `latest`.
+
+Após a release, crie um novo commit bumpando o projeto para a próxima versão `-SNAPSHOT`.
+
+## Verificação pós-release
+
+Após publicar `v1.0.0`, valide:
+
+```bash
+curl -L -o cpf-matcher-1.0.0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v1.0.0/cpf-matcher-1.0.0.jar
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0 show-config
+```
+
+Ao iniciar o Keycloak em ambiente de teste, confirme nos logs que o provider `cpf-matcher` foi carregado.
 
 ## Estrutura
 

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.edu.unifesspa.uniplus</groupId>
         <artifactId>keycloak-providers</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>cpf-matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.edu.unifesspa.uniplus</groupId>
     <artifactId>keycloak-providers</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
 
     <name>Uni+ Keycloak Providers</name>
@@ -44,18 +44,18 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <!-- Keycloak alvo: alinhado com docker-compose do uniplus-api -->
-        <keycloak.version>26.5.0</keycloak.version>
+        <!-- Keycloak alvo: alinhado com a imagem GHCR do Uni+ -->
+        <keycloak.version>26.5.7</keycloak.version>
 
         <!-- Test stack -->
-        <junit.version>5.10.2</junit.version>
-        <mockito.version>5.11.0</mockito.version>
-        <assertj.version>3.25.3</assertj.version>
+        <junit.version>5.12.2</junit.version>
+        <mockito.version>5.18.0</mockito.version>
+        <assertj.version>3.27.3</assertj.version>
 
         <!-- Plugin versions -->
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
-        <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Resumo
- bumpa o projeto para 1.0.0 e alinha Keycloak/dependências/plugins Maven com versões pinadas
- adiciona Dockerfile multistage para publicar a imagem ghcr.io/unifesspa-edu-br/uniplus-keycloak
- adiciona workflow de release por tag v*.*.* com GitHub Release, checksum SHA-256 e push no GHCR
- documenta consumo da imagem, visibilidade pública do package, processo de release e verificação pós-release

## Validação
- docker run --rm --user 1000:1000 -v /home/jeferson/Projects/workspaces/uniplus/repositories/uniplus-keycloak-providers:/workspace -v /home/jeferson/.m2:/home/jeferson/.m2 -e MAVEN_CONFIG=/home/jeferson/.m2 -w /workspace maven:3.9-eclipse-temurin-21 mvn clean package
- Surefire XML: 38 testes, 0 falhas, 0 erros, 0 skipped
- docker build -t test/uniplus-keycloak:dev .
- docker run --rm --entrypoint /bin/sh test/uniplus-keycloak:dev -c 'ls -1 /opt/keycloak/providers && /opt/keycloak/bin/kc.sh show-config >/tmp/keycloak-show-config.txt && sed -n "'1,12p"' /tmp/keycloak-show-config.txt'

Closes #7