### PR TITLE
fix(release): gerar checksum com nome portável

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,19 +35,22 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           minor="${version%.*}"
           jar="cpf-matcher/target/cpf-matcher-${version}.jar"
+          artifact_dir="$(dirname "$jar")"
+          artifact_name="$(basename "$jar")"
+          checksum="${jar}.sha256"
 
           if [ ! -f "$jar" ]; then
             echo "::error::JAR esperado não encontrado: $jar"
             exit 1
           fi
 
-          sha256sum "$jar" > "${jar}.sha256"
+          (cd "$artifact_dir" && sha256sum "$artifact_name") > "$checksum"
 
           {
             echo "version=$version"
             echo "minor=$minor"
             echo "jar=$jar"
-            echo "checksum=${jar}.sha256"
+            echo "checksum=$checksum"
             echo "image=ghcr.io/${GITHUB_REPOSITORY_OWNER}/uniplus-keycloak"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Resumo
- ajusta o workflow de release para gerar o arquivo .sha256 a partir do diretório do artefato
- mantém o upload do checksum em cpf-matcher/target, mas o conteúdo agora referencia apenas cpf-matcher-<versão>.jar
- corrige o cenário em que usuários baixam os dois assets do Release em um diretório comum e executam sha256sum -c

## Validação
- docker run --rm --user 1000:1000 -v /home/jeferson/Projects/workspaces/uniplus/repositories/uniplus-keycloak-providers:/workspace -v /home/jeferson/.m2:/home/jeferson/.m2 -e MAVEN_CONFIG=/home/jeferson/.m2 -w /workspace maven:3.9-eclipse-temurin-21 mvn clean package
- Surefire XML: 38 testes, 0 falhas, 0 erros, 0 skipped
- simulação do bloco Resolve release version para v1.0.0 gerou: '1a3b70d19aa18bda3c7c16105c44068e1a2ccefc6b23d6cd84ecf2dc265eb821  cpf-matcher-1.0.0.jar'
- git diff --check

Follow-up do review pós-merge do PR #8.