### PR TITLE
fix(docker): adiciona CMD default para evitar restart loop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,12 @@ LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/unipl
       org.opencontainers.image.version="${VERSION}"
 
 COPY --from=builder /workspace/cpf-matcher/target/cpf-matcher-*.jar /opt/keycloak/providers/
+
+# Default CMD para evitar restart loop quando o operador esquece o `command:`
+# no compose/manifesto. Sem `--optimized` para manter a imagem agnóstica de
+# build-time options (KC_DB, KC_HEALTH_ENABLED, KC_FEATURES) — testes de
+# integração usam H2/dev-mem, HML e PROD usam Postgres. O preço é ~20s a
+# mais no primeiro boot enquanto o `kc.sh start` faz a augmentation com a
+# config efetiva do container; reboots subsequentes reaproveitam o cache.
+# Override em DEV: `command: ["start-dev", "--import-realm"]`.
+CMD ["start"]


### PR DESCRIPTION
## Summary

Adiciona `CMD ["start"]` ao Dockerfile da imagem `uniplus-keycloak` para evitar restart loop quando o operador esquece de declarar `command:` no compose/manifesto.

## Problema

A imagem v1.0.0 publicada não define `CMD`, então o `ENTRYPOINT` `kc.sh` recebe argumentos vazios e imprime a tela de help, saindo com exit 0. Em containers com `restart: unless-stopped`/`always`, o resultado é restart loop infinito.

Situação observada em campo: deploy HML (`docker-compose.yml` em `/root/keycloak/`) sem `command:` no serviço Keycloak — `RestartCount: 21` e logs com kc.sh help repetidos.

## Decisão de design

Sem `--optimized` e sem bakar build-time options (`KC_DB`, `KC_HEALTH_ENABLED`, etc.):
- Testes de integração do `uniplus-api` rodam contra H2/dev-mem para velocidade
- HML/PROD usam Postgres
- Bakar `KC_DB=postgres` faria `start --optimized` recusar o boot quando o env runtime divergir

Tradeoff: primeiro boot leva ~20-30s a mais (augmentation feita com a config do container). Reboots seguintes reaproveitam o cache.

## Validação local (test image)

| Cenário | KC_DB | Boot | cpf-matcher SPI | Listening |
|---|---|---|---|---|
| Postgres (HML) | postgres | 2.7s pós-build | ✓ carregado | http://0.0.0.0:8080 |
| H2 dev-mem (tests) | dev-mem | 6.5s | ✓ carregado | http://0.0.0.0:8080 |

`docker inspect` confirma `Cmd=[start]` baked, `Entrypoint=[/opt/keycloak/bin/kc.sh]`.

## Test plan

- [ ] CI build verde
- [ ] Após merge, gerar release v1.0.1 e republicar imagem
- [ ] Validar drop-in em HML (operador remove `command:` do compose, sobe com a v1.0.1)

Refs unifesspa-edu-br/uniplus-api#218
