### PR TITLE
chore(release): bump versão para 1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn clean package -DskipTests
 
 FROM quay.io/keycloak/keycloak:26.5.7 AS runtime
 
-ARG VERSION=1.0.0
+ARG VERSION=1.0.2
 
 LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-keycloak-providers" \
       org.opencontainers.image.licenses="Apache-2.0" \

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.edu.unifesspa.uniplus</groupId>
         <artifactId>keycloak-providers</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>cpf-matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.edu.unifesspa.uniplus</groupId>
     <artifactId>keycloak-providers</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2</version>
     <packaging>pom</packaging>
 
     <name>Uni+ Keycloak Providers</name>


### PR DESCRIPTION
## Summary

Bump da versão para 1.0.2 — pré-requisito para republicar a imagem após o fix do CMD default no Dockerfile (PR #10, mergeado em 13:17Z).

## Por que 1.0.2 e não 1.0.1

A tag `v1.0.1` foi pushada após o merge do PR #10 mas o workflow de release [falhou](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/actions/runs/25215701235) porque o pom seguia em 1.0.0 — JAR gerado `cpf-matcher-1.0.0.jar`, pipeline esperava `cpf-matcher-1.0.1.jar`.

Convenção: versões falhadas viram histórico e não são reusadas. A `v1.0.1` permanece como audit trail; `v1.0.2` é a próxima válida.

## Mudanças

- `pom.xml` (parent): `1.0.0` → `1.0.2`
- `cpf-matcher/pom.xml` (parent ref): `1.0.0` → `1.0.2`
- `Dockerfile`: `ARG VERSION` default `1.0.0` → `1.0.2` (workflow continua sobrescrevendo via `--build-arg` em CI; default só afeta builds manuais)

## Test plan

- [ ] CI verde
- [ ] Após merge, taggear `v1.0.2` na main → workflow `Release` publica `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2`
- [ ] Validar imagem drop-in em HML: trocar tag para `1.0.2` no compose, remover `command:`

Refs unifesspa-edu-br/uniplus-api#218
