### PR TITLE
chore(release): bump Keycloak base 26.5.7 → 26.6.1 + retag scheme :KC-PATCH (#13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Tag scheme: v<KC-VERSION>-<PATCH-PROVIDERS>, ex.: v26.6.1-0
+          # version    = 26.6.1-0  (release imutável; pinning estrito)
+          # kc_patch   = 26.6.1    (soft-pin: último patch dos providers Uni+ sobre KC 26.6.1)
           version="${GITHUB_REF_NAME#v}"
-          minor="${version%.*}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' não bate com o scheme esperado v<KC>-<PATCH> (ex.: v26.6.1-0). Sem -<PATCH>, a soft-pin :<KC> colidiria com a release imutável."
+            exit 1
+          fi
+          kc_patch="${version%-*}"
           jar="cpf-matcher/target/cpf-matcher-${version}.jar"
           artifact_dir="$(dirname "$jar")"
           artifact_name="$(basename "$jar")"
@@ -48,7 +55,7 @@ jobs:
 
           {
             echo "version=$version"
-            echo "minor=$minor"
+            echo "kc_patch=$kc_patch"
             echo "jar=$jar"
             echo "checksum=$checksum"
             echo "image=ghcr.io/${GITHUB_REPOSITORY_OWNER}/uniplus-keycloak"
@@ -88,5 +95,5 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
           tags: |
             ${{ steps.version.outputs.image }}:${{ steps.version.outputs.version }}
-            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.minor }}
+            ${{ steps.version.outputs.image }}:${{ steps.version.outputs.kc_patch }}
             ${{ steps.version.outputs.image }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY cpf-matcher/src cpf-matcher/src
 
 RUN mvn clean package -DskipTests
 
-FROM quay.io/keycloak/keycloak:26.5.7 AS runtime
+FROM quay.io/keycloak/keycloak:26.6.1 AS runtime
 
-ARG VERSION=1.0.2
+ARG VERSION=26.6.1-0
 
 LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-keycloak-providers" \
       org.opencontainers.image.licenses="Apache-2.0" \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Providers customizados em Java SPI para o **Keycloak** institucional da platafor
 
 - **Java:** 21 LTS
 - **Build:** Maven 3.9+
-- **Keycloak alvo:** 26.5.7
+- **Keycloak alvo:** 26.6.1
 
 ## Build
 
@@ -35,49 +35,68 @@ Em **homologação/produção**, o JAR é incluído na imagem Docker do Keycloak
 A imagem oficial de consumo dos providers Uni+ é publicada no GHCR:
 
 ```bash
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
 ```
+
+### Tag scheme
+
+`ghcr.io/unifesspa-edu-br/uniplus-keycloak:<KC-VERSION>-<PATCH>` onde:
+
+- `<KC-VERSION>` = versão exata do Keycloak base (ex.: `26.6.1`)
+- `<PATCH>` = revisão dos providers Uni+ sobre essa base (`-0`, `-1`, `-2`, …)
+
+A cada release, três tags Docker são publicadas:
+
+| Tag | Aponta para | Uso |
+|---|---|---|
+| `:26.6.1-0` | release imutável | pinning estrito (PROD, HML) |
+| `:26.6.1` | último patch dos providers Uni+ sobre KC `26.6.1` | soft-pin dentro da mesma KC version |
+| `:latest` | última release publicada | dev/exploração |
+
+> **Migração do scheme legado `:1.x`** — descontinuado a partir de `26.6.1-0`. Tags `:1.0.x` continuam pulláveis no GHCR mas não recebem atualizações. Migrar pinning para `:<KC>-<PATCH>`.
+
+### Por ambiente
 
 Para **DEV**, substitua a imagem base do Keycloak no `docker-compose.yml` do `uniplus-api`:
 
 ```yaml
-image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
 ```
 
-Essa substituição entra no lugar de `quay.io/keycloak/keycloak:26.5`. O caminho legacy de desenvolvimento local continua suportado para quem trabalha no SPI: compilar o JAR com Maven e montar o arquivo gerado em `/opt/keycloak/providers/`.
+O caminho legacy de desenvolvimento local continua suportado para quem trabalha no SPI: compilar o JAR com Maven e montar o arquivo gerado em `/opt/keycloak/providers/`.
 
-Para **HML/PRD**, o Helm chart deve apontar para a mesma imagem versionada:
+Para **HML/PRD/standalone**, o Helm chart deve apontar para a mesma imagem versionada:
 
 ```text
-ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
 ```
 
-A imagem precisa ficar pública após o primeiro push, porque o repositório é público e DEV/HML/PRD não devem depender de autenticação para pull. No GitHub, confira em **Packages > uniplus-keycloak > Package settings > Danger Zone > Change visibility** e ajuste para **Public** se necessário.
+A imagem precisa ficar pública após o primeiro push, porque o repositório é público e os ambientes não devem depender de autenticação para pull. No GitHub, confira em **Packages > uniplus-keycloak > Package settings > Danger Zone > Change visibility** e ajuste para **Public** se necessário.
 
 ## Como fazer release
 
-1. Ajustar o `pom.xml` para a próxima versão sem `-SNAPSHOT`.
+1. Ajustar o `pom.xml` (raiz e `cpf-matcher/pom.xml`), o `Dockerfile` (`ARG VERSION`) e o `<keycloak.version>` em `pom.xml` para a próxima versão alinhada ao Keycloak alvo (`<KC>-<PATCH>`).
 2. Executar `mvn clean package` e validar os testes.
 3. Fazer commit e push da alteração.
 4. Criar e enviar a tag:
 
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git tag v26.6.1-0
+git push origin v26.6.1-0
 ```
 
-O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `1.0.0`, `1.0` e `latest`.
+O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, valida o formato `v<KC>-<PATCH>` e — se válido — publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `26.6.1-0`, `26.6.1` e `latest`. Tags fora do formato (ex.: `v26.6.1` sem `-<PATCH>`) abortam o workflow para evitar colisão entre release imutável e soft-pin.
 
-Após a release, crie um novo commit bumpando o projeto para a próxima versão `-SNAPSHOT`.
+Após a release, faça um novo commit bumpando os 3 arquivos de versão (`pom.xml`, `cpf-matcher/pom.xml`, `Dockerfile` `ARG VERSION`) para a próxima `-SNAPSHOT` esperada — ex.: `26.6.1-1-SNAPSHOT` se planejar nova patch dos providers sobre o mesmo KC 26.6.1, ou `26.6.2-0-SNAPSHOT` se for acompanhar bump do Keycloak. Isso evita que `mvn package` local regenere artefato com versão idêntica à release publicada.
 
 ## Verificação pós-release
 
-Após publicar `v1.0.0`, valide:
+Após publicar `v26.6.1-0`, valide:
 
 ```bash
-curl -L -o cpf-matcher-1.0.0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v1.0.0/cpf-matcher-1.0.0.jar
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
-docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0 show-config
+curl -L -o cpf-matcher-26.6.1-0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v26.6.1-0/cpf-matcher-26.6.1-0.jar
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
+docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0 show-config
 ```
 
 Ao iniciar o Keycloak em ambiente de teste, confirme nos logs que o provider `cpf-matcher` foi carregado.

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.edu.unifesspa.uniplus</groupId>
         <artifactId>keycloak-providers</artifactId>
-        <version>1.0.2</version>
+        <version>26.6.1-0</version>
     </parent>
 
     <artifactId>cpf-matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.edu.unifesspa.uniplus</groupId>
     <artifactId>keycloak-providers</artifactId>
-    <version>1.0.2</version>
+    <version>26.6.1-0</version>
     <packaging>pom</packaging>
 
     <name>Uni+ Keycloak Providers</name>
@@ -44,8 +44,8 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <!-- Keycloak alvo: alinhado com a imagem GHCR do Uni+ -->
-        <keycloak.version>26.5.7</keycloak.version>
+        <!-- Keycloak alvo: alinhado com a imagem GHCR do Uni+ (`uniplus-keycloak:<KC>-<patch>`) -->
+        <keycloak.version>26.6.1</keycloak.version>
 
         <!-- Test stack -->
         <junit.version>5.12.2</junit.version>


### PR DESCRIPTION
## Resumo

Substitui o scheme opaco `:1.x` pelo padrão `:<KC-VERSION>-<PATCH>` (ex.: `:26.6.1-0`), seguindo a versão upstream do Keycloak para identificação direta. A imagem composta passa a ser consumível pelo standalone do `uniplus-infra` (e demais ambientes HML/PROD), garantindo que validamos exatamente o binário que vai pra produção.

## O que mudou

| Arquivo | Mudança |
|---|---|
| `Dockerfile` | `FROM …:26.5.7` → `:26.6.1`; `ARG VERSION=1.0.2` → `ARG VERSION=26.6.1-0` |
| `pom.xml` | `<version>1.0.2</version>` → `<version>26.6.1-0</version>`; `<keycloak.version>26.5.7</keycloak.version>` → `26.6.1` |
| `cpf-matcher/pom.xml` | `<parent><version>1.0.2</version>` → `<version>26.6.1-0</version>` |
| `.github/workflows/release.yml` | Cálculo de tag via `${version%-*}` publicando 3 tags (`:26.6.1-0`, `:26.6.1`, `:latest`); valida regex `v<KC>-<PATCH>` para evitar colisão entre release imutável e soft-pin |
| `README.md` | Nova seção "Tag scheme" + atualização do procedimento de release (com bump `-SNAPSHOT` pós-release reintroduzido) |

## Tag scheme novo

`ghcr.io/unifesspa-edu-br/uniplus-keycloak:<KC-VERSION>-<PATCH>` onde:

- `<KC-VERSION>` = versão exata do Keycloak base
- `<PATCH>` = revisão dos providers Uni+ sobre essa base (`-0`, `-1`, …)

A cada release, três tags Docker:

| Tag | Aponta para | Uso |
|---|---|---|
| `:26.6.1-0` | release imutável | pinning estrito (PROD, HML) |
| `:26.6.1` | último patch dos providers Uni+ sobre KC `26.6.1` | soft-pin |
| `:latest` | última release publicada | dev |

**Sem alias `:1.x` de transição**: tags `:1.0.x` continuam pulláveis no GHCR mas não recebem atualizações; consumidores devem migrar pinning para `:<KC>-<PATCH>` na próxima oportunidade.

## Validação local

```bash
docker build --build-arg VERSION=26.6.1-0 -t uniplus-keycloak:26.6.1-0-test .
# BUILD SUCCESS — JAR cpf-matcher-26.6.1-0.jar compilado contra SPI 26.6.1
# Imagem 473MB com /opt/keycloak/providers/cpf-matcher-26.6.1-0.jar
docker inspect uniplus-keycloak:26.6.1-0-test --format '{{json .Config.Labels}}' | jq '.["org.opencontainers.image.version"]'
# → "26.6.1-0"
```

Testes não rodam no `docker build` (usa `-DskipTests` para acelerar build da imagem); rodarão no workflow `release.yml` que faz `mvn clean package` completo.

## Codex CLI local review

`codex exec` rodado pré-PR; 0 P1, 4 P2/P3 — 3 acionáveis aplicados antes do commit:

- **P2.1** — Workflow agora valida regex `^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$` e aborta tags fora do scheme
- **P2.2** — README troca "último patch da série KC 26.6.1" por "último patch dos providers Uni+ sobre KC 26.6.1" (evita confundir com patch do upstream)
- **P3.1** — Reintroduzida orientação de bump para `-SNAPSHOT` pós-release no README

P3 sobre divergência potencial entre `Dockerfile ARG` e `pom.xml`: não aplicado por já existir safety net no workflow (linha 42-45 falha se JAR esperado não estiver presente em `cpf-matcher/target/`).

## Próximo passo (manual, pós-merge)

```bash
git tag v26.6.1-0
git push origin v26.6.1-0
```

Workflow `release.yml` dispara, publica `:26.6.1-0`, `:26.6.1`, `:latest` no GHCR + GitHub Release com JAR + checksum.

## Critério de aceite (issue #13)

- [x] Dockerfile + pom.xml + workflow alinhados ao novo scheme
- [x] README atualizado com nova convenção
- [x] Build local valida JAR + image OK
- [ ] CI de PR verde
- [ ] Após merge, tag `v26.6.1-0` push → 3 tags Docker públicas + Release GitHub
- [ ] Imagem `:26.6.1-0` consumida com sucesso pelo `uniplus-infra` (Etapa B / unifesspa-edu-br/uniplus-infra#191)

## Riscos

- **Compatibilidade SPI 26.5.7 → 26.6.1**: mesma major, API estável, mas testes runtime virão pelo CI mvn.
- **Tag scheme breaking**: nenhum consumidor ativo confirmado pinando `:1.x` em produção; standalone está em vanilla, lab-* a confirmar.

Closes #13
Refs unifesspa-edu-br/uniplus-infra#186, unifesspa-edu-br/uniplus-infra#190, unifesspa-edu-br/uniplus-infra#191