### PR TITLE
fix: sobe base para Keycloak 26.6.4 (CVEs de segurança + migração Postgres)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY cpf-matcher/src cpf-matcher/src
 
 RUN mvn clean package -DskipTests
 
-FROM quay.io/keycloak/keycloak:26.6.1 AS runtime
+FROM quay.io/keycloak/keycloak:26.6.4 AS runtime
 
-ARG VERSION=26.6.1-0
+ARG VERSION=26.6.4-0
 
 LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-keycloak-providers" \
       org.opencontainers.image.licenses="Apache-2.0" \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Providers customizados em Java SPI para o **Keycloak** institucional da platafor
 
 - **Java:** 21 LTS
 - **Build:** Maven 3.9+
-- **Keycloak alvo:** 26.6.1
+- **Keycloak alvo:** 26.6.4
 
 ## Build
 
@@ -35,22 +35,22 @@ Em **homologação/produção**, o JAR é incluído na imagem Docker do Keycloak
 A imagem oficial de consumo dos providers Uni+ é publicada no GHCR:
 
 ```bash
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
 ```
 
 ### Tag scheme
 
 `ghcr.io/unifesspa-edu-br/uniplus-keycloak:<KC-VERSION>-<PATCH>` onde:
 
-- `<KC-VERSION>` = versão exata do Keycloak base (ex.: `26.6.1`)
+- `<KC-VERSION>` = versão exata do Keycloak base (ex.: `26.6.4`)
 - `<PATCH>` = revisão dos providers Uni+ sobre essa base (`-0`, `-1`, `-2`, …)
 
 A cada release, três tags Docker são publicadas:
 
 | Tag | Aponta para | Uso |
 |---|---|---|
-| `:26.6.1-0` | release imutável | pinning estrito (PROD, HML) |
-| `:26.6.1` | último patch dos providers Uni+ sobre KC `26.6.1` | soft-pin dentro da mesma KC version |
+| `:26.6.4-0` | release imutável | pinning estrito (PROD, HML) |
+| `:26.6.4` | último patch dos providers Uni+ sobre KC `26.6.4` | soft-pin dentro da mesma KC version |
 | `:latest` | última release publicada | dev/exploração |
 
 > **Migração do scheme legado `:1.x`** — descontinuado a partir de `26.6.1-0`. Tags `:1.0.x` continuam pulláveis no GHCR mas não recebem atualizações. Migrar pinning para `:<KC>-<PATCH>`.
@@ -60,7 +60,7 @@ A cada release, três tags Docker são publicadas:
 Para **DEV**, substitua a imagem base do Keycloak no `docker-compose.yml` do `uniplus-api`:
 
 ```yaml
-image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
+image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
 ```
 
 O caminho legacy de desenvolvimento local continua suportado para quem trabalha no SPI: compilar o JAR com Maven e montar o arquivo gerado em `/opt/keycloak/providers/`.
@@ -68,7 +68,7 @@ O caminho legacy de desenvolvimento local continua suportado para quem trabalha 
 Para **HML/PRD/standalone**, o Helm chart deve apontar para a mesma imagem versionada:
 
 ```text
-ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
+ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
 ```
 
 A imagem precisa ficar pública após o primeiro push, porque o repositório é público e os ambientes não devem depender de autenticação para pull. No GitHub, confira em **Packages > uniplus-keycloak > Package settings > Danger Zone > Change visibility** e ajuste para **Public** se necessário.
@@ -81,22 +81,22 @@ A imagem precisa ficar pública após o primeiro push, porque o repositório é 
 4. Criar e enviar a tag:
 
 ```bash
-git tag v26.6.1-0
-git push origin v26.6.1-0
+git tag v26.6.4-0
+git push origin v26.6.4-0
 ```
 
-O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, valida o formato `v<KC>-<PATCH>` e — se válido — publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `26.6.1-0`, `26.6.1` e `latest`. Tags fora do formato (ex.: `v26.6.1` sem `-<PATCH>`) abortam o workflow para evitar colisão entre release imutável e soft-pin.
+O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, valida o formato `v<KC>-<PATCH>` e — se válido — publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `26.6.4-0`, `26.6.4` e `latest`. Tags fora do formato (ex.: `v26.6.4` sem `-<PATCH>`) abortam o workflow para evitar colisão entre release imutável e soft-pin.
 
-Após a release, faça um novo commit bumpando os 3 arquivos de versão (`pom.xml`, `cpf-matcher/pom.xml`, `Dockerfile` `ARG VERSION`) para a próxima `-SNAPSHOT` esperada — ex.: `26.6.1-1-SNAPSHOT` se planejar nova patch dos providers sobre o mesmo KC 26.6.1, ou `26.6.2-0-SNAPSHOT` se for acompanhar bump do Keycloak. Isso evita que `mvn package` local regenere artefato com versão idêntica à release publicada.
+Após a release, faça um novo commit bumpando os 3 arquivos de versão (`pom.xml`, `cpf-matcher/pom.xml`, `Dockerfile` `ARG VERSION`) para a próxima `-SNAPSHOT` esperada — ex.: `26.6.4-1-SNAPSHOT` se planejar nova patch dos providers sobre o mesmo KC 26.6.4, ou `26.7.0-0-SNAPSHOT` se for acompanhar bump do Keycloak. Isso evita que `mvn package` local regenere artefato com versão idêntica à release publicada.
 
 ## Verificação pós-release
 
-Após publicar `v26.6.1-0`, valide:
+Após publicar `v26.6.4-0`, valide:
 
 ```bash
-curl -L -o cpf-matcher-26.6.1-0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v26.6.1-0/cpf-matcher-26.6.1-0.jar
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0
-docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.1-0 show-config
+curl -L -o cpf-matcher-26.6.4-0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v26.6.4-0/cpf-matcher-26.6.4-0.jar
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
+docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0 show-config
 ```
 
 Ao iniciar o Keycloak em ambiente de teste, confirme nos logs que o provider `cpf-matcher` foi carregado.

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.edu.unifesspa.uniplus</groupId>
         <artifactId>keycloak-providers</artifactId>
-        <version>26.6.1-0</version>
+        <version>26.6.4-0</version>
     </parent>
 
     <artifactId>cpf-matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.edu.unifesspa.uniplus</groupId>
     <artifactId>keycloak-providers</artifactId>
-    <version>26.6.1-0</version>
+    <version>26.6.4-0</version>
     <packaging>pom</packaging>
 
     <name>Uni+ Keycloak Providers</name>
@@ -45,7 +45,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Keycloak alvo: alinhado com a imagem GHCR do Uni+ (`uniplus-keycloak:<KC>-<patch>`) -->
-        <keycloak.version>26.6.1</keycloak.version>
+        <keycloak.version>26.6.4</keycloak.version>
 
         <!-- Test stack -->
         <junit.version>5.12.2</junit.version>


### PR DESCRIPTION
## O que muda

Sobe a imagem composta de **Keycloak 26.6.1 → 26.6.4** (último patch estável da linha 26.6.x).

| Arquivo | Antes | Depois |
|---|---|---|
| `Dockerfile` (`FROM` + `ARG VERSION`) | `26.6.1` / `26.6.1-0` | `26.6.4` / `26.6.4-0` |
| `pom.xml` (`<version>`, `<keycloak.version>`) | `26.6.1-0` / `26.6.1` | `26.6.4-0` / `26.6.4` |
| `cpf-matcher/pom.xml` (parent) | `26.6.1-0` | `26.6.4-0` |
| `README.md` | alvo/exemplos `26.6.1` | `26.6.4` |

## Por quê — segurança + correção de migração

O `26.6.4` (26/06/2026) corrige cumulativamente:

- **8 CVEs de segurança**, vários críticos para um IdP: **CVE-2026-11800** (authentication bypass via JWT algorithm confusion), **CVE-2026-9099** (privilege escalation group-admin → realm-admin), **CVE-2026-9799/9800** (authorization bypass), entre outros (XSS, info disclosure, scope mapping).
- O bug de migração Postgres [keycloak/keycloak#48438](https://github.com/keycloak/keycloak/issues/48438) (corrigido no 26.6.3, incluído no 26.6.4): migração 26.5→26.6 abortava em restart loop.

Como esta imagem é deployada em HML/PROD, ir direto para `26.6.4` evita publicar uma versão com CVEs conhecidos. `26.6.4` é a última estável recomendada (quay.io + downloads oficiais; não há 26.7.x estável).

## Validação local

Maven 3.9 / Java 21 (igual ao `release.yml`), contra a API do KC 26.6.4:

- `keycloak-core:26.6.4` resolvido do Maven Central;
- `cpf-matcher` compila; **38 testes, 0 falhas**;
- JAR gerado: `cpf-matcher-26.6.4-0.jar`.

## Pós-merge (publicação da imagem)

```bash
git tag v26.6.4-0
git push origin v26.6.4-0
```

Publica no GHCR as tags `26.6.4-0`, `26.6.4` e `latest`.

## Follow-ups (após a imagem publicada)

- `unifesspa-geo-api#11`: bumpar fixture + `docker-compose` para `26.6.4` e remover o workaround.
- `uniplus-infra`: bumpar `values.yaml` para `26.6.4-0`.
- `uniplus-api`: migrar fixture/compose do esquema `1.0.x` para `26.6.4`.

Closes #15