### PR TITLE
fix(repo): sobe base para Keycloak 26.7.2 e fecha CVE-2026-18963

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY cpf-matcher/src cpf-matcher/src
 
 RUN mvn clean package -DskipTests
 
-FROM quay.io/keycloak/keycloak:26.6.4 AS runtime
+FROM quay.io/keycloak/keycloak:26.7.2 AS runtime
 
-ARG VERSION=26.6.4-0
+ARG VERSION=26.7.2-0
 
 LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-keycloak-providers" \
       org.opencontainers.image.licenses="Apache-2.0" \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Providers customizados em Java SPI para o **Keycloak** institucional da platafor
 
 - **Java:** 21 LTS
 - **Build:** Maven 3.9+
-- **Keycloak alvo:** 26.6.4
+- **Keycloak alvo:** 26.7.2
 
 ## Build
 
@@ -35,22 +35,22 @@ Em **homologação/produção**, o JAR é incluído na imagem Docker do Keycloak
 A imagem oficial de consumo dos providers Uni+ é publicada no GHCR:
 
 ```bash
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0
 ```
 
 ### Tag scheme
 
 `ghcr.io/unifesspa-edu-br/uniplus-keycloak:<KC-VERSION>-<PATCH>` onde:
 
-- `<KC-VERSION>` = versão exata do Keycloak base (ex.: `26.6.4`)
+- `<KC-VERSION>` = versão exata do Keycloak base (ex.: `26.7.2`)
 - `<PATCH>` = revisão dos providers Uni+ sobre essa base (`-0`, `-1`, `-2`, …)
 
 A cada release, três tags Docker são publicadas:
 
 | Tag | Aponta para | Uso |
 |---|---|---|
-| `:26.6.4-0` | release imutável | pinning estrito (PROD, HML) |
-| `:26.6.4` | último patch dos providers Uni+ sobre KC `26.6.4` | soft-pin dentro da mesma KC version |
+| `:26.7.2-0` | release imutável | pinning estrito (PROD, HML) |
+| `:26.7.2` | último patch dos providers Uni+ sobre KC `26.7.2` | soft-pin dentro da mesma KC version |
 | `:latest` | última release publicada | dev/exploração |
 
 > **Migração do scheme legado `:1.x`** — descontinuado a partir de `26.6.1-0`. Tags `:1.0.x` continuam pulláveis no GHCR mas não recebem atualizações. Migrar pinning para `:<KC>-<PATCH>`.
@@ -60,7 +60,7 @@ A cada release, três tags Docker são publicadas:
 Para **DEV**, substitua a imagem base do Keycloak no `docker-compose.yml` do `uniplus-api`:
 
 ```yaml
-image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
+image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0
 ```
 
 O caminho legacy de desenvolvimento local continua suportado para quem trabalha no SPI: compilar o JAR com Maven e montar o arquivo gerado em `/opt/keycloak/providers/`.
@@ -68,38 +68,67 @@ O caminho legacy de desenvolvimento local continua suportado para quem trabalha 
 Para **HML/PRD/standalone**, o Helm chart deve apontar para a mesma imagem versionada:
 
 ```text
-ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
+ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0
 ```
 
 A imagem precisa ficar pública após o primeiro push, porque o repositório é público e os ambientes não devem depender de autenticação para pull. No GitHub, confira em **Packages > uniplus-keycloak > Package settings > Danger Zone > Change visibility** e ajuste para **Public** se necessário.
 
 ## Como fazer release
 
-1. Ajustar o `pom.xml` (raiz e `cpf-matcher/pom.xml`), o `Dockerfile` (`ARG VERSION`) e o `<keycloak.version>` em `pom.xml` para a próxima versão alinhada ao Keycloak alvo (`<KC>-<PATCH>`).
+1. Ajustar os cinco pontos de versão para a próxima release alinhada ao Keycloak alvo (`<KC>-<PATCH>`): `<version>` do `pom.xml` raiz, `<version>` do `<parent>` em `cpf-matcher/pom.xml`, `ARG VERSION` no `Dockerfile`, `<keycloak.version>` no `pom.xml` raiz e o `FROM quay.io/keycloak/keycloak:<KC>` no `Dockerfile`. Os dois últimos só mudam quando a base do Keycloak muda — e precisam mudar **juntos**, senão o provider compila contra uma versão de SPI diferente da que roda no container.
 2. Executar `mvn clean package` e validar os testes.
 3. Fazer commit e push da alteração.
 4. Criar e enviar a tag:
 
 ```bash
-git tag v26.6.4-0
-git push origin v26.6.4-0
+git tag v26.7.2-0
+git push origin v26.7.2-0
 ```
 
-O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, valida o formato `v<KC>-<PATCH>` e — se válido — publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `26.6.4-0`, `26.6.4` e `latest`. Tags fora do formato (ex.: `v26.6.4` sem `-<PATCH>`) abortam o workflow para evitar colisão entre release imutável e soft-pin.
+O workflow `.github/workflows/release.yml` dispara automaticamente para tags `v*.*.*`, valida o formato `v<KC>-<PATCH>` e — se válido — publica o JAR e o checksum SHA-256 no GitHub Release e envia a imagem Docker para o GHCR com as tags `26.7.2-0`, `26.7.2` e `latest`. Tags fora do formato (ex.: `v26.7.2` sem `-<PATCH>`) abortam o workflow para evitar colisão entre release imutável e soft-pin.
 
-Após a release, faça um novo commit bumpando os 3 arquivos de versão (`pom.xml`, `cpf-matcher/pom.xml`, `Dockerfile` `ARG VERSION`) para a próxima `-SNAPSHOT` esperada — ex.: `26.6.4-1-SNAPSHOT` se planejar nova patch dos providers sobre o mesmo KC 26.6.4, ou `26.7.0-0-SNAPSHOT` se for acompanhar bump do Keycloak. Isso evita que `mvn package` local regenere artefato com versão idêntica à release publicada.
+Após a release, faça um novo commit bumpando a versão para a próxima `-SNAPSHOT` esperada. Isso
+evita que `mvn package` local regenere artefato com versão idêntica à release publicada.
+
+**Nova patch dos providers sobre o mesmo Keycloak** (ex.: `26.7.2-1-SNAPSHOT`) — três pontos:
+
+- `pom.xml` → `<version>`
+- `cpf-matcher/pom.xml` → `<version>` do `<parent>`
+- `Dockerfile` → `ARG VERSION`
+
+**Acompanhando bump do Keycloak** (ex.: `26.8.0-0-SNAPSHOT`) — os três acima **e mais dois**, sem
+os quais a imagem sai tagueada com a versão nova rodando o Keycloak antigo:
+
+- `pom.xml` → `<keycloak.version>` (versão das SPIs contra as quais o provider compila)
+- `Dockerfile` → `FROM quay.io/keycloak/keycloak:<KC>` (base efetiva do runtime)
+
+Antes de fixar o alvo, confirme que a tag existe no registry upstream — as correções publicadas em
+branches do Red Hat Build of Keycloak não têm contrapartida em `quay.io/keycloak/keycloak`.
 
 ## Verificação pós-release
 
-Após publicar `v26.6.4-0`, valide:
+Após publicar `v26.7.2-0`, valide:
 
 ```bash
-curl -L -o cpf-matcher-26.6.4-0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v26.6.4-0/cpf-matcher-26.6.4-0.jar
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0
-docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4-0 show-config
+curl -L -o cpf-matcher-26.7.2-0.jar https://github.com/unifesspa-edu-br/uniplus-keycloak-providers/releases/download/v26.7.2-0/cpf-matcher-26.7.2-0.jar
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0
+docker run --rm ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0 show-config
 ```
 
-Ao iniciar o Keycloak em ambiente de teste, confirme nos logs que o provider `cpf-matcher` foi carregado.
+Ao iniciar o Keycloak em ambiente de teste, confirme que o provider foi registrado — consultar a
+lista de authenticators é determinístico, o log não é:
+
+```bash
+token=$(curl -s -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli -d "username=$KC_ADMIN" -d "password=$KC_ADMIN_PASSWORD" \
+  | jq -r .access_token)
+curl -s -H "Authorization: Bearer $token" "$KC_URL/admin/realms/master/authentication/authenticator-providers" \
+  | jq '.[] | select(.id == "uniplus-cpf-matcher")'
+```
+
+O provider ausente devolve saída vazia. No log de arranque, a linha `KC-SERVICES0047` citando
+`uniplus-cpf-matcher` confirma que o JAR foi lido — é aviso esperado, não erro: o Keycloak marca
+assim todo provider que implementa a SPI interna `authenticator`.
 
 ## Estrutura
 

--- a/cpf-matcher/README.md
+++ b/cpf-matcher/README.md
@@ -1,6 +1,6 @@
 # cpf-matcher
 
-Authenticator SPI para Keycloak 26.5 que faz matching tolerante por **CPF** entre identidades federadas (gov.br) e users existentes no realm — incluindo o caso do LDAP institucional Unifesspa com `brPersonCPF` truncado em 10 dígitos.
+Authenticator SPI para Keycloak 26.7 que faz matching tolerante por **CPF** entre identidades federadas (gov.br) e users existentes no realm — incluindo o caso do LDAP institucional Unifesspa com `brPersonCPF` truncado em 10 dígitos.
 
 ## Por que existe
 
@@ -44,7 +44,7 @@ Em **todos** os caminhos (encontrou ou não), o Authenticator chama `context.att
 mvn clean package
 ```
 
-Gera `cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar`.
+Gera `cpf-matcher/target/cpf-matcher-26.7.2-0.jar`.
 
 ## Como deployar (dev local)
 
@@ -53,7 +53,7 @@ O `docker-compose.yml` do **uniplus-api** monta o JAR em `/opt/keycloak/provider
 ```yaml
 keycloak:
   volumes:
-    - ../uniplus-keycloak-providers/cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar:/opt/keycloak/providers/cpf-matcher.jar
+    - ../uniplus-keycloak-providers/cpf-matcher/target/cpf-matcher-26.7.2-0.jar:/opt/keycloak/providers/cpf-matcher.jar
   command: ["start-dev", "--import-realm"]
 ```
 
@@ -97,9 +97,12 @@ Testes unitários cobrem:
 Nível **info** registra qual tentativa de matching funcionou:
 
 ```
-CPF matcher: user existente encontrado por CPF canônico (11 dig) — username='lara.almeida'
-CPF matcher: user existente encontrado via fallback LDAP malformado (10 dig) — username='kevin.peixoto'. Aplicando auto-heal do atributo cpf para formato canônico.
+CPF matcher: matching direto (formato canônico) — userId='4f1c9a2e-...'
+CPF matcher: matching via fallback (LDAP malformado) — userId='9b0d7e51-...', aplicando auto-heal
 ```
+
+O identificador registrado é o `userId` (UUID interno do Keycloak), nunca o `username` — no LDAP
+institucional o username é `nome.sobrenome`, dado pessoal sob a LGPD.
 
 Nível **debug** registra os casos em que delega ao próximo executor.
 

--- a/cpf-matcher/pom.xml
+++ b/cpf-matcher/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>br.edu.unifesspa.uniplus</groupId>
         <artifactId>keycloak-providers</artifactId>
-        <version>26.6.4-0</version>
+        <version>26.7.2-0</version>
     </parent>
 
     <artifactId>cpf-matcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>br.edu.unifesspa.uniplus</groupId>
     <artifactId>keycloak-providers</artifactId>
-    <version>26.6.4-0</version>
+    <version>26.7.2-0</version>
     <packaging>pom</packaging>
 
     <name>Uni+ Keycloak Providers</name>
@@ -45,7 +45,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Keycloak alvo: alinhado com a imagem GHCR do Uni+ (`uniplus-keycloak:<KC>-<patch>`) -->
-        <keycloak.version>26.6.4</keycloak.version>
+        <keycloak.version>26.7.2</keycloak.version>
 
         <!-- Test stack -->
         <junit.version>5.12.2</junit.version>


### PR DESCRIPTION
## Resumo

Sobe a base da imagem `uniplus-keycloak` de Keycloak **26.6.4** para **26.7.2**, fechando o
**CVE-2026-18963** (CVSS 9.1) — tomada de conta por usuário não autenticado, incluindo `admin`, via
validação de estado incorreta no fluxo `reset-credentials` do `keycloak-services`. A próxima release
publica `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.7.2-0`.

## Por que 26.7.2 e não 26.6.6

A cobertura do CVE cita `26.4.15` e `26.6.6` como versões corrigidas, mas essas são **branches do
Red Hat Build of Keycloak**. Esta imagem é construída sobre o **Keycloak upstream**, onde nenhuma das
duas existe. Consulta à API do quay:

| Tag | `quay.io/keycloak/keycloak` |
|---|---|
| `26.6.4` | existe (base atual) |
| `26.6.5` | não existe — lista de tags vazia |
| `26.6.6` | não existe — branch do RHBK |
| `26.7.0` / `26.7.1` / `26.7.2` | existem |
| `26.7.3` / `26.8.0` | não existem |

Primeiro alvo corrigido disponível upstream: **26.7.2**.

## Mudanças

**Bump (commit 1)** — os cinco pontos de versão:

| Arquivo | De | Para |
|---|---|---|
| `Dockerfile` `FROM` | `26.6.4` | `26.7.2` |
| `Dockerfile` `ARG VERSION` | `26.6.4-0` | `26.7.2-0` |
| `pom.xml` `<version>` | `26.6.4-0` | `26.7.2-0` |
| `pom.xml` `<keycloak.version>` | `26.6.4` | `26.7.2` |
| `cpf-matcher/pom.xml` parent | `26.6.4-0` | `26.7.2-0` |

**Documentação (commit 2)** — referências de versão nos dois READMEs, mais três correções que a
revisão do bump expôs:

- O passo de release listava **três** pontos de versão a ajustar. Quando o bump acompanha o
  Keycloak são **cinco**: seguindo a instrução ao pé da letra, `<keycloak.version>` e o `FROM` ficam
  para trás e a imagem sai tagueada com a versão nova rodando a base antiga. Agora explícitos, com a
  ressalva de conferir a tag no registry upstream antes de fixar o alvo — foi exatamente onde a
  `26.6.6` do RHBK enganou aqui.
- A verificação pós-release mandava "confirmar nos logs que o provider foi carregado", o que não é
  determinístico — o provider não registra linha própria no arranque. Passa a consultar a lista de
  authenticators pela API de administração, que devolve saída vazia quando o provider não subiu.
- O README do `cpf-matcher` declarava Keycloak 26.5, citava o JAR no esquema `1.0.0-SNAPSHOT` e
  mostrava exemplos de log com `username='nome.sobrenome'` — dado pessoal que o código deixou de
  emitir quando os logs passaram a usar o UUID interno do Keycloak.

A nota histórica sobre a descontinuação do scheme legado `:1.x` a partir de `26.6.1-0` fica intacta:
é registro do passado, não da versão vigente.

## Risco: SPI não é estável entre minors

Não é bump de patch — é salto de minor (26.6 → 26.7), e a comunidade não garante compatibilidade das
SPIs entre minors. Superfície do `cpf-matcher` contra o Keycloak: `AbstractIdpAuthenticator`
(+ `EXISTING_USER_INFO`), `ExistingUserInfo`, `SerializedBrokeredIdentityContext`,
`BrokeredIdentityContext`, `UserProvider.searchForUserByUserAttributeStream`, `UserModel`,
`AuthenticatorFactory`, `ProviderConfigProperty`, `AuthenticationExecutionModel.Requirement`.

## Test plan

Sem JDK 21 nem Maven no host — build e boot rodaram em container.

- [x] `mvn clean verify` em `maven:3.9-eclipse-temurin-21` contra as SPIs 26.7.2 — **38 testes
      verdes**, compilação sem aviso de depreciação ou remoção.
- [x] `docker build` da imagem completa a partir do `Dockerfile` alterado.
- [x] Conteúdo da imagem: `/opt/keycloak/providers/cpf-matcher-26.7.2-0.jar`, e em
      `/opt/keycloak/lib` os artefatos `keycloak-services`, `keycloak-core`, `keycloak-server-spi` e
      `keycloak-server-spi-private` — todos `26.7.2`. `kc.sh --version` reporta `Keycloak 26.7.2`.
- [x] Boot em `start-dev`: arranque limpo em 5,7s, sem erro. Log traz `KC-SERVICES0047` citando
      `uniplus-cpf-matcher` — aviso esperado, marca todo provider que implementa a SPI interna
      `authenticator`.
- [x] Registro confirmado pela API de administração: `uniplus-cpf-matcher` aparece em
      `/admin/realms/master/authentication/authenticator-providers`, com `displayName` e `helpText`
      corretos, entre os 43 authenticators disponíveis. Evidência determinística, ao contrário do log.

**Não exercitado:** o matching fim-a-fim. Exige realm com IdP gov.br federado e LDAP institucional
com CPF truncado — não reproduzível localmente. Fica como risco residual; a validação de comportamento
acontece em homologação, na `uniplus-infra#525`.

## Notas ao revisor

- **Rollback não é "trocar a tag de volta".** Um upgrade de minor do Keycloak pode aplicar migração
  de schema, e o Keycloak não suporta downgrade de banco — voltar para `26.6.4-0` contra um banco já
  migrado pode impedir o arranque. A pré-condição operacional é backup do banco **antes** de promover
  a imagem, e o rollback é restore + tag anterior. Isso é responsabilidade de quem promove
  (`uniplus-infra#525`), não deste repositório.
- **Release é manual e posterior ao merge**, conforme o README: `git tag v26.7.2-0 && git push origin
  v26.7.2-0` dispara o `release.yml`. Este PR não publica nada.
- **Mudanças de tema de login na 26.7** (layout horizontal dos botões de ação, ícones de vendor em
  passkey) não afetam este repositório — ele não carrega tema customizado.

## Impacto além deste repositório

Esta issue desbloqueia as demais; cada consumidor acompanha na sua:

- `unifesspa-edu-br/uniplus-infra#525` — mitigação imediata em homologação e promoção da imagem
- `unifesspa-edu-br/uniplus-api#1290` — `docker-compose.yml` e `KeycloakContainerFixture`
- `unifesspa-edu-br/uniplus-web#590` — E2E, hoje ainda em `1.0.2` (base 26.5.7)

Closes #17